### PR TITLE
Switch stable publish to PR-based version bump

### DIFF
--- a/.github/workflows/ci-stable.yml
+++ b/.github/workflows/ci-stable.yml
@@ -104,7 +104,8 @@ jobs:
           print(f"stable.toml -> {stable_version}")
           print(f"dev.toml    -> {dev_version}")
           PY
-      - name: Commit bumped versions back to main (signed via GitHub API)
+      - name: Push signed bump commit to a release branch
+        id: bump_commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
@@ -114,12 +115,39 @@ jobs:
           import json
           import os
           import subprocess
+          import urllib.error
           import urllib.request
 
           head_oid = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
           repo = os.environ["GITHUB_REPOSITORY"]
           token = os.environ["GH_TOKEN"]
           version = os.environ["VERSION"]
+          branch = f"release/bump-v{version}"
+
+          def api(path, method="GET", body=None):
+              req = urllib.request.Request(
+                  f"https://api.github.com/{path}",
+                  data=(json.dumps(body).encode("utf-8") if body is not None else None),
+                  headers={
+                      "Authorization": f"Bearer {token}",
+                      "Accept": "application/vnd.github+json",
+                      "Content-Type": "application/json",
+                  },
+                  method=method,
+              )
+              with urllib.request.urlopen(req) as resp:
+                  raw = resp.read()
+                  return json.loads(raw) if raw else None
+
+          try:
+              api(
+                  f"repos/{repo}/git/refs",
+                  method="POST",
+                  body={"ref": f"refs/heads/{branch}", "sha": head_oid},
+              )
+          except urllib.error.HTTPError as error:
+              if error.code != 422:  # 422 = ref already exists; OK to reuse
+                  raise
 
           def b64(path: str) -> str:
               with open(path, "rb") as fp:
@@ -139,7 +167,7 @@ jobs:
                   "input": {
                       "branch": {
                           "repositoryNameWithOwner": repo,
-                          "branchName": "main",
+                          "branchName": branch,
                       },
                       "message": {
                           "headline": f"Bump version to v{version} [skip ci]",
@@ -169,8 +197,31 @@ jobs:
               body = json.loads(resp.read())
           if body.get("errors"):
               raise SystemExit(f"GraphQL error: {body['errors']}")
-          print(body["data"]["createCommitOnBranch"]["commit"])
+          commit = body["data"]["createCommitOnBranch"]["commit"]
+          print(f"bump commit: {commit['oid']} -> {commit['url']}")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fp:
+              fp.write(f"branch={branch}\n")
+              fp.write(f"oid={commit['oid']}\n")
           PY
+      - name: Open PR for the version bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          BRANCH: ${{ steps.bump_commit.outputs.branch }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Bump version to v${VERSION} [skip ci]" \
+            --body "Automated patch bump emitted by the stable publish workflow. [skip ci]"
+      - name: Try to auto-merge the bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.bump_commit.outputs.branch }}
+        run: |
+          gh pr merge "$BRANCH" --squash --auto --delete-branch \
+            || echo "auto-merge unavailable; PR left open for manual merge"
       - name: Use stable.toml as pyproject.toml
         run: cp stable.toml pyproject.toml
       - name: Build sdist and wheel
@@ -185,7 +236,9 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUMP_OID: ${{ steps.bump_commit.outputs.oid }}
         run: |
           gh release create "v${{ steps.version.outputs.version }}" dist/* \
             --title "v${{ steps.version.outputs.version }}" \
-            --generate-notes
+            --generate-notes \
+            --target "$BUMP_OID"


### PR DESCRIPTION
## Summary
- Replace the direct-push-to-main version bump (blocked by branch protection: required signed commits + PR-only) with a PR flow
- CI creates a `release/bump-v<version>` branch and pushes the bumped `stable.toml` + `dev.toml` via the GraphQL `createCommitOnBranch` mutation, producing a signed commit
- Workflow then opens a PR with `[skip ci]` in title/body and tries `gh pr merge --squash --auto --delete-branch`; if auto-merge is unavailable the PR is left open for manual merge
- The GitHub Release tag now targets the signed bump commit SHA so it survives whether or not the PR ever merges

## Test plan
- [ ] Merge this PR to `main` and confirm the publish job completes end-to-end
- [ ] Verify the auto-generated bump PR is signed, has `[skip ci]`, and either auto-merges or stays open cleanly
- [ ] Confirm the PyPI upload and GitHub Release (tagged at the bump commit) succeed