### PR TITLE
Grant pull-requests:write to stable publish job

### DIFF
--- a/.github/workflows/ci-stable.yml
+++ b/.github/workflows/ci-stable.yml
@@ -65,6 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
gh pr create uses the GraphQL createPullRequest mutation, which needs pull-requests:write on GITHUB_TOKEN. Without it the workflow fails with 'Resource not accessible by integration'.