### PR TITLE
Refresh system architecture diagram in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,105 +55,235 @@ facade.
 ## Architecture
 
 ```mermaid
-flowchart LR
-    User[User / CLI / JSON batch]
+flowchart TD
+    CLI["<b>CLI / JSON batch</b><br/>python -m automation_file"]
+    GUIUser["<b>PySide6 GUI</b><br/>launch_ui"]
+    ClientSDK["<b>HTTPActionClient SDK</b>"]
+    MCPHost["<b>MCP hosts</b><br/>Claude Desktop · MCP CLIs"]
+    Plugins["<b>Entry-point plugins</b><br/>automation_file.actions"]
 
-    subgraph Facade["automation_file (facade)"]
-        Public["Public API<br/>execute_action, execute_action_parallel,<br/>validate_action, driver_instance,<br/>start_autocontrol_socket_server,<br/>start_http_action_server, Quota,<br/>retry_on_transient, safe_join, ..."]
+    subgraph Facade["<b>automation_file &mdash; facade (__init__.py)</b>"]
+        PublicAPI["<b>Public API</b><br/>execute_action · execute_action_parallel · execute_action_dag<br/>validate_action · driver_instance · s3_instance · azure_blob_instance<br/>dropbox_instance · sftp_instance · ftp_instance · onedrive_instance · box_instance<br/>start_autocontrol_socket_server · start_http_action_server<br/>start_metrics_server · start_web_ui · MCPServer<br/>notification_manager · scheduler · trigger_manager<br/>AutomationConfig · progress_registry · Quota · retry_on_transient"]
     end
 
-    subgraph Core["core"]
-        Registry[(ActionRegistry<br/>FA_* commands)]
-        Executor[ActionExecutor]
-        Callback[CallbackExecutor]
-        Loader[PackageLoader]
-        Json[json_store]
-        Retry[retry]
-        QuotaMod[quota]
-        Progress[progress<br/>Token + Reporter]
+    subgraph Core["<b>core</b>"]
+        Registry[("<b>ActionRegistry</b><br/>FA_* commands")]
+        Executor["<b>ActionExecutor</b><br/>serial · parallel · dry-run · validate-first"]
+        DAG["<b>dag_executor</b><br/>topological fan-out"]
+        Callback["<b>CallbackExecutor</b>"]
+        Loader["<b>PackageLoader</b><br/>+ entry-point plugins"]
+        Queue["<b>ActionQueue</b>"]
+        Json["<b>json_store</b>"]
+        Sub["<b>substitution</b><br/>${env:} ${date:} ${uuid}"]
     end
 
-    subgraph Events["event-driven"]
-        TriggerMod["trigger<br/>watchdog file watcher"]
-        SchedulerMod["scheduler<br/>cron background thread"]
+    subgraph Reliability["<b>reliability</b>"]
+        Retry["<b>retry</b><br/>@retry_on_transient"]
+        QuotaMod["<b>Quota</b><br/>bytes + time budget"]
+        Breaker["<b>CircuitBreaker</b>"]
+        RL["<b>RateLimiter</b>"]
+        Locks["<b>FileLock</b> · <b>SQLiteLock</b>"]
     end
 
-    subgraph Local["local"]
-        FileOps[file_ops]
-        DirOps[dir_ops]
-        ZipOps[zip_ops]
-        Safe[safe_paths]
+    subgraph Observability["<b>observability</b>"]
+        Progress["<b>progress</b><br/>CancellationToken · Reporter"]
+        Metrics["<b>metrics</b><br/>Prometheus counters + histograms"]
+        Audit["<b>AuditLog</b><br/>SQLite"]
+        Tracing["<b>tracing</b><br/>OpenTelemetry spans"]
+        FIM["<b>IntegrityMonitor</b>"]
     end
 
-    subgraph Remote["remote"]
-        UrlVal[url_validator]
-        Http[http_download]
-        Drive["google_drive<br/>client + *_ops"]
-        S3["s3"]
-        Azure["azure_blob"]
-        Dropbox["dropbox_api"]
-        SFTP["sftp"]
+    subgraph Security["<b>security &amp; config</b>"]
+        Secrets["<b>Secret providers</b><br/>Env · File · Chained"]
+        Config["<b>AutomationConfig</b><br/>TOML loader"]
+        ConfW["<b>ConfigWatcher</b><br/>hot reload"]
+        Crypto["<b>crypto</b><br/>AES-256-GCM"]
+        Check["<b>checksum</b> / <b>manifest</b>"]
+        SafeP["<b>safe_paths</b><br/>safe_join · is_within"]
+        ACL["<b>ActionACL</b>"]
     end
 
-    subgraph Server["server"]
-        TCP[TCPActionServer]
-        HTTP[HTTPActionServer]
+    subgraph Events["<b>event-driven</b>"]
+        Trigger["<b>TriggerManager</b><br/>watchdog file watcher"]
+        Sched["<b>Scheduler</b><br/>5-field cron + overlap guard"]
     end
 
-    subgraph UI["ui (PySide6)"]
-        Launcher[launch_ui]
-        MainWindow["MainWindow<br/>9-tab control surface"]
+    subgraph Servers["<b>servers</b>"]
+        TCP["<b>TCPActionServer</b><br/>loopback · AUTH secret"]
+        HTTPS["<b>HTTPActionServer</b><br/>POST /actions · Bearer<br/>/healthz /readyz /progress /openapi.json"]
+        MCP["<b>MCPServer</b><br/>JSON-RPC 2.0 (stdio)"]
+        MetSrv["<b>MetricsServer</b><br/>/metrics"]
+        WebUI["<b>WebUIServer</b><br/>HTMX dashboard"]
     end
 
-    subgraph Project["project / utils"]
-        Builder[ProjectBuilder]
-        Templates[templates]
-        Discovery[file_discovery]
+    subgraph UI["<b>ui (PySide6)</b>"]
+        MainWin["<b>MainWindow</b><br/>Home · Local · HTTP · Drive · S3 · Azure · Dropbox<br/>SFTP · OneDrive · Box · JSON · Triggers · Scheduler<br/>Progress · Transfer · Servers"]
+        Worker["<b>ActionWorker</b><br/>QRunnable on QThreadPool"]
     end
 
-    User --> Public
-    User --> Launcher
-    Launcher --> MainWindow
-    MainWindow --> Public
-    Public --> Executor
-    Public --> Callback
-    Public --> Loader
-    Public --> TCP
-    Public --> HTTP
+    subgraph Local["<b>local ops</b>"]
+        FileOps["<b>file_ops</b> · <b>dir_ops</b>"]
+        Archives["<b>zip_ops</b> · <b>tar_ops</b> · <b>archive_ops</b>"]
+        DataOps["<b>data_ops</b><br/>csv · jsonl · parquet · yaml"]
+        TextOps["<b>text_ops</b> · <b>diff_ops</b><br/><b>json_edit</b> · <b>templates</b>"]
+        Misc["<b>shell_ops</b> · <b>sync_ops</b> · <b>trash</b><br/><b>versioning</b> · <b>conditional</b> · <b>mime</b>"]
+    end
 
-    Executor --> Registry
-    Executor --> Retry
-    Executor --> QuotaMod
-    Callback --> Registry
-    Loader --> Registry
-    TCP --> Executor
-    HTTP --> Executor
-    Executor --> Json
+    subgraph Remote["<b>remote backends</b>"]
+        UrlVal["<b>url_validator</b><br/>SSRF guard"]
+        Http["<b>http_download</b><br/>retry · resume · SHA-256"]
+        Drive["<b>google_drive</b>"]
+        S3M["<b>s3</b>"]
+        Azure["<b>azure_blob</b>"]
+        Dropbox["<b>dropbox_api</b>"]
+        SFTP["<b>sftp</b> (RejectPolicy)"]
+        FTP["<b>ftp / FTPS</b>"]
+        OneD["<b>onedrive</b>"]
+        Box["<b>box</b>"]
+        WebDAV["<b>webdav</b>"]
+        SMB["<b>smb / cifs</b>"]
+        Fsspec["<b>fsspec_bridge</b>"]
+        Cross["<b>cross_backend</b><br/>local:// s3:// drive:// azure://<br/>dropbox:// sftp:// ftp://"]
+    end
 
-    Registry --> FileOps
-    Registry --> DirOps
-    Registry --> ZipOps
-    Registry --> Safe
-    Registry --> Http
-    Registry --> Drive
-    Registry --> S3
-    Registry --> Azure
-    Registry --> Dropbox
-    Registry --> SFTP
-    Registry --> Builder
-    Registry --> TriggerMod
-    Registry --> SchedulerMod
-    Registry --> Progress
+    subgraph Notify["<b>notifications</b>"]
+        NM["<b>NotificationManager</b><br/>fanout · dedup · SSRF guard"]
+        Sinks["<b>Sinks</b><br/>Webhook · Slack · Email<br/>Telegram · Discord · Teams · PagerDuty"]
+    end
 
-    TriggerMod --> Executor
-    SchedulerMod --> Executor
-    Http --> Progress
-    S3 --> Progress
+    subgraph Utils["<b>utils / project</b>"]
+        Fast["<b>fast_find</b><br/>mdfind / locate / es.exe"]
+        Dedup["<b>find_duplicates</b>"]
+        Grep["<b>grep_files</b>"]
+        Rotate["<b>rotate_backups</b>"]
+        Discovery["<b>file_discovery</b>"]
+        Builder["<b>ProjectBuilder</b> + templates"]
+    end
 
-    Http --> UrlVal
-    Http --> Retry
-    Builder --> Templates
-    Builder --> Discovery
+    CLI ==> PublicAPI
+    GUIUser ==> MainWin
+    ClientSDK ==> HTTPS
+    MCPHost ==> MCP
+    Plugins ==> Loader
+
+    MainWin ==> Worker
+    Worker ==> PublicAPI
+
+    PublicAPI ==> Executor
+    PublicAPI ==> DAG
+    PublicAPI ==> Callback
+    PublicAPI ==> Queue
+    PublicAPI ==> Config
+    PublicAPI ==> NM
+    PublicAPI ==> Trigger
+    PublicAPI ==> Sched
+
+    TCP ==> Executor
+    HTTPS ==> Executor
+    MCP ==> Registry
+    MetSrv ==> Metrics
+    WebUI ==> Registry
+    ACL ==> TCP
+    ACL ==> HTTPS
+
+    Executor ==> Registry
+    Executor ==> Sub
+    Executor ==> Retry
+    Executor ==> QuotaMod
+    Executor ==> Metrics
+    Executor ==> Audit
+    Executor ==> Tracing
+    Executor ==> Json
+    DAG ==> Executor
+    Callback ==> Registry
+    Loader ==> Registry
+
+    Trigger ==> Executor
+    Sched ==> Executor
+    Trigger -. on failure .-> NM
+    Sched -. on failure .-> NM
+    FIM -. on drift .-> NM
+    ConfW ==> Config
+    Config ==> Secrets
+    Config ==> NM
+
+    Registry ==> FileOps
+    Registry ==> Archives
+    Registry ==> DataOps
+    Registry ==> TextOps
+    Registry ==> Misc
+    Registry ==> Http
+    Registry ==> Drive
+    Registry ==> S3M
+    Registry ==> Azure
+    Registry ==> Dropbox
+    Registry ==> SFTP
+    Registry ==> FTP
+    Registry ==> OneD
+    Registry ==> Box
+    Registry ==> WebDAV
+    Registry ==> SMB
+    Registry ==> Fsspec
+    Registry ==> Cross
+    Registry ==> Crypto
+    Registry ==> Check
+    Registry ==> Fast
+    Registry ==> Dedup
+    Registry ==> Grep
+    Registry ==> Rotate
+    Registry ==> Discovery
+    Registry ==> Builder
+    Registry ==> Progress
+
+    FileOps ==> SafeP
+    Archives ==> SafeP
+    Misc ==> SafeP
+
+    Http ==> UrlVal
+    Http ==> Retry
+    Http ==> Progress
+    Http ==> Check
+    S3M ==> Progress
+    WebDAV ==> UrlVal
+    NM ==> UrlVal
+    NM ==> Sinks
+
+    Cross ==> Drive
+    Cross ==> S3M
+    Cross ==> Azure
+    Cross ==> Dropbox
+    Cross ==> SFTP
+    Cross ==> FTP
+
+    classDef entry fill:#FDEDEC,stroke:#641E16,stroke-width:3px,color:#000,font-weight:bold;
+    classDef facade fill:#D6EAF8,stroke:#154360,stroke-width:4px,color:#000,font-weight:bold;
+    classDef core fill:#FEF9E7,stroke:#1F3A93,stroke-width:3px,color:#000,font-weight:bold;
+    classDef rel fill:#D1F2EB,stroke:#0B5345,stroke-width:3px,color:#000,font-weight:bold;
+    classDef obs fill:#FDEBD0,stroke:#9C640C,stroke-width:3px,color:#000,font-weight:bold;
+    classDef sec fill:#F5B7B1,stroke:#78281F,stroke-width:3px,color:#000,font-weight:bold;
+    classDef event fill:#FCF3CF,stroke:#7D6608,stroke-width:3px,color:#000,font-weight:bold;
+    classDef server fill:#FADBD8,stroke:#922B21,stroke-width:3px,color:#000,font-weight:bold;
+    classDef ui fill:#AED6F1,stroke:#1B4F72,stroke-width:3px,color:#000,font-weight:bold;
+    classDef localOps fill:#E8DAEF,stroke:#512E5F,stroke-width:3px,color:#000,font-weight:bold;
+    classDef remote fill:#D5F5E3,stroke:#196F3D,stroke-width:3px,color:#000,font-weight:bold;
+    classDef notify fill:#F9E79F,stroke:#7D6608,stroke-width:3px,color:#000,font-weight:bold;
+    classDef utils fill:#EAEDED,stroke:#212F3C,stroke-width:3px,color:#000,font-weight:bold;
+
+    class CLI,GUIUser,ClientSDK,MCPHost,Plugins entry;
+    class PublicAPI facade;
+    class Registry,Executor,DAG,Callback,Loader,Queue,Json,Sub core;
+    class Retry,QuotaMod,Breaker,RL,Locks rel;
+    class Progress,Metrics,Audit,Tracing,FIM obs;
+    class Secrets,Config,ConfW,Crypto,Check,SafeP,ACL sec;
+    class Trigger,Sched event;
+    class TCP,HTTPS,MCP,MetSrv,WebUI server;
+    class MainWin,Worker ui;
+    class FileOps,Archives,DataOps,TextOps,Misc localOps;
+    class UrlVal,Http,Drive,S3M,Azure,Dropbox,SFTP,FTP,OneD,Box,WebDAV,SMB,Fsspec,Cross remote;
+    class NM,Sinks notify;
+    class Fast,Dedup,Grep,Rotate,Discovery,Builder utils;
+
+    linkStyle default stroke:#1F2A44,stroke-width:2.5px;
 ```
 
 The `ActionRegistry` built by `build_default_registry()` is the single source

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,105 +53,235 @@ TCP / HTTP 服务器执行的 JSON 驱动动作。内附 PySide6 GUI，每个功
 ## 架构
 
 ```mermaid
-flowchart LR
-    User[User / CLI / JSON batch]
+flowchart TD
+    CLI["<b>CLI / JSON 批次</b><br/>python -m automation_file"]
+    GUIUser["<b>PySide6 GUI</b><br/>launch_ui"]
+    ClientSDK["<b>HTTPActionClient SDK</b>"]
+    MCPHost["<b>MCP 主机</b><br/>Claude Desktop · MCP CLIs"]
+    Plugins["<b>入口点插件</b><br/>automation_file.actions"]
 
-    subgraph Facade["automation_file (facade)"]
-        Public["Public API<br/>execute_action, execute_action_parallel,<br/>validate_action, driver_instance,<br/>start_autocontrol_socket_server,<br/>start_http_action_server, Quota,<br/>retry_on_transient, safe_join, ..."]
+    subgraph Facade["<b>automation_file &mdash; 门面 (__init__.py)</b>"]
+        PublicAPI["<b>Public API</b><br/>execute_action · execute_action_parallel · execute_action_dag<br/>validate_action · driver_instance · s3_instance · azure_blob_instance<br/>dropbox_instance · sftp_instance · ftp_instance · onedrive_instance · box_instance<br/>start_autocontrol_socket_server · start_http_action_server<br/>start_metrics_server · start_web_ui · MCPServer<br/>notification_manager · scheduler · trigger_manager<br/>AutomationConfig · progress_registry · Quota · retry_on_transient"]
     end
 
-    subgraph Core["core"]
-        Registry[(ActionRegistry<br/>FA_* commands)]
-        Executor[ActionExecutor]
-        Callback[CallbackExecutor]
-        Loader[PackageLoader]
-        Json[json_store]
-        Retry[retry]
-        QuotaMod[quota]
-        Progress[progress<br/>Token + Reporter]
+    subgraph Core["<b>core 核心</b>"]
+        Registry[("<b>ActionRegistry</b><br/>FA_* 命令")]
+        Executor["<b>ActionExecutor</b><br/>串行 · 并行 · dry-run · validate-first"]
+        DAG["<b>dag_executor</b><br/>拓扑调度 fan-out"]
+        Callback["<b>CallbackExecutor</b>"]
+        Loader["<b>PackageLoader</b><br/>+ 入口点插件"]
+        Queue["<b>ActionQueue</b>"]
+        Json["<b>json_store</b>"]
+        Sub["<b>substitution</b><br/>${env:} ${date:} ${uuid}"]
     end
 
-    subgraph Events["event-driven"]
-        TriggerMod["trigger<br/>watchdog file watcher"]
-        SchedulerMod["scheduler<br/>cron background thread"]
+    subgraph Reliability["<b>可靠性</b>"]
+        Retry["<b>retry</b><br/>@retry_on_transient"]
+        QuotaMod["<b>Quota</b><br/>字节 + 时间配额"]
+        Breaker["<b>CircuitBreaker</b>"]
+        RL["<b>RateLimiter</b>"]
+        Locks["<b>FileLock</b> · <b>SQLiteLock</b>"]
     end
 
-    subgraph Local["local"]
-        FileOps[file_ops]
-        DirOps[dir_ops]
-        ZipOps[zip_ops]
-        Safe[safe_paths]
+    subgraph Observability["<b>可观测性</b>"]
+        Progress["<b>progress</b><br/>CancellationToken · Reporter"]
+        Metrics["<b>metrics</b><br/>Prometheus counters + histograms"]
+        Audit["<b>AuditLog</b><br/>SQLite 审计日志"]
+        Tracing["<b>tracing</b><br/>OpenTelemetry spans"]
+        FIM["<b>IntegrityMonitor</b>"]
     end
 
-    subgraph Remote["remote"]
-        UrlVal[url_validator]
-        Http[http_download]
-        Drive["google_drive<br/>client + *_ops"]
-        S3["s3"]
-        Azure["azure_blob"]
-        Dropbox["dropbox_api"]
-        SFTP["sftp"]
+    subgraph Security["<b>安全 &amp; 配置</b>"]
+        Secrets["<b>Secret providers</b><br/>Env · File · Chained"]
+        Config["<b>AutomationConfig</b><br/>TOML 加载器"]
+        ConfW["<b>ConfigWatcher</b><br/>热重载"]
+        Crypto["<b>crypto</b><br/>AES-256-GCM"]
+        Check["<b>checksum</b> / <b>manifest</b>"]
+        SafeP["<b>safe_paths</b><br/>safe_join · is_within"]
+        ACL["<b>ActionACL</b>"]
     end
 
-    subgraph Server["server"]
-        TCP[TCPActionServer]
-        HTTP[HTTPActionServer]
+    subgraph Events["<b>事件驱动</b>"]
+        Trigger["<b>TriggerManager</b><br/>watchdog 文件监听"]
+        Sched["<b>Scheduler</b><br/>5-field cron + overlap guard"]
     end
 
-    subgraph UI["ui (PySide6)"]
-        Launcher[launch_ui]
-        MainWindow["MainWindow<br/>9-tab control surface"]
+    subgraph Servers["<b>服务器</b>"]
+        TCP["<b>TCPActionServer</b><br/>loopback · AUTH secret"]
+        HTTPS["<b>HTTPActionServer</b><br/>POST /actions · Bearer<br/>/healthz /readyz /progress /openapi.json"]
+        MCP["<b>MCPServer</b><br/>JSON-RPC 2.0 (stdio)"]
+        MetSrv["<b>MetricsServer</b><br/>/metrics"]
+        WebUI["<b>WebUIServer</b><br/>HTMX dashboard"]
     end
 
-    subgraph Project["project / utils"]
-        Builder[ProjectBuilder]
-        Templates[templates]
-        Discovery[file_discovery]
+    subgraph UI["<b>ui (PySide6)</b>"]
+        MainWin["<b>MainWindow</b><br/>Home · Local · HTTP · Drive · S3 · Azure · Dropbox<br/>SFTP · OneDrive · Box · JSON · Triggers · Scheduler<br/>Progress · Transfer · Servers"]
+        Worker["<b>ActionWorker</b><br/>QRunnable on QThreadPool"]
     end
 
-    User --> Public
-    User --> Launcher
-    Launcher --> MainWindow
-    MainWindow --> Public
-    Public --> Executor
-    Public --> Callback
-    Public --> Loader
-    Public --> TCP
-    Public --> HTTP
+    subgraph Local["<b>本地 ops</b>"]
+        FileOps["<b>file_ops</b> · <b>dir_ops</b>"]
+        Archives["<b>zip_ops</b> · <b>tar_ops</b> · <b>archive_ops</b>"]
+        DataOps["<b>data_ops</b><br/>csv · jsonl · parquet · yaml"]
+        TextOps["<b>text_ops</b> · <b>diff_ops</b><br/><b>json_edit</b> · <b>templates</b>"]
+        Misc["<b>shell_ops</b> · <b>sync_ops</b> · <b>trash</b><br/><b>versioning</b> · <b>conditional</b> · <b>mime</b>"]
+    end
 
-    Executor --> Registry
-    Executor --> Retry
-    Executor --> QuotaMod
-    Callback --> Registry
-    Loader --> Registry
-    TCP --> Executor
-    HTTP --> Executor
-    Executor --> Json
+    subgraph Remote["<b>远程后端</b>"]
+        UrlVal["<b>url_validator</b><br/>SSRF 保护"]
+        Http["<b>http_download</b><br/>retry · resume · SHA-256"]
+        Drive["<b>google_drive</b>"]
+        S3M["<b>s3</b>"]
+        Azure["<b>azure_blob</b>"]
+        Dropbox["<b>dropbox_api</b>"]
+        SFTP["<b>sftp</b> (RejectPolicy)"]
+        FTP["<b>ftp / FTPS</b>"]
+        OneD["<b>onedrive</b>"]
+        Box["<b>box</b>"]
+        WebDAV["<b>webdav</b>"]
+        SMB["<b>smb / cifs</b>"]
+        Fsspec["<b>fsspec_bridge</b>"]
+        Cross["<b>cross_backend</b><br/>local:// s3:// drive:// azure://<br/>dropbox:// sftp:// ftp://"]
+    end
 
-    Registry --> FileOps
-    Registry --> DirOps
-    Registry --> ZipOps
-    Registry --> Safe
-    Registry --> Http
-    Registry --> Drive
-    Registry --> S3
-    Registry --> Azure
-    Registry --> Dropbox
-    Registry --> SFTP
-    Registry --> Builder
-    Registry --> TriggerMod
-    Registry --> SchedulerMod
-    Registry --> Progress
+    subgraph Notify["<b>通知</b>"]
+        NM["<b>NotificationManager</b><br/>fanout · dedup · SSRF guard"]
+        Sinks["<b>Sinks</b><br/>Webhook · Slack · Email<br/>Telegram · Discord · Teams · PagerDuty"]
+    end
 
-    TriggerMod --> Executor
-    SchedulerMod --> Executor
-    Http --> Progress
-    S3 --> Progress
+    subgraph Utils["<b>工具 / 项目</b>"]
+        Fast["<b>fast_find</b><br/>mdfind / locate / es.exe"]
+        Dedup["<b>find_duplicates</b>"]
+        Grep["<b>grep_files</b>"]
+        Rotate["<b>rotate_backups</b>"]
+        Discovery["<b>file_discovery</b>"]
+        Builder["<b>ProjectBuilder</b> + templates"]
+    end
 
-    Http --> UrlVal
-    Http --> Retry
-    Builder --> Templates
-    Builder --> Discovery
+    CLI ==> PublicAPI
+    GUIUser ==> MainWin
+    ClientSDK ==> HTTPS
+    MCPHost ==> MCP
+    Plugins ==> Loader
+
+    MainWin ==> Worker
+    Worker ==> PublicAPI
+
+    PublicAPI ==> Executor
+    PublicAPI ==> DAG
+    PublicAPI ==> Callback
+    PublicAPI ==> Queue
+    PublicAPI ==> Config
+    PublicAPI ==> NM
+    PublicAPI ==> Trigger
+    PublicAPI ==> Sched
+
+    TCP ==> Executor
+    HTTPS ==> Executor
+    MCP ==> Registry
+    MetSrv ==> Metrics
+    WebUI ==> Registry
+    ACL ==> TCP
+    ACL ==> HTTPS
+
+    Executor ==> Registry
+    Executor ==> Sub
+    Executor ==> Retry
+    Executor ==> QuotaMod
+    Executor ==> Metrics
+    Executor ==> Audit
+    Executor ==> Tracing
+    Executor ==> Json
+    DAG ==> Executor
+    Callback ==> Registry
+    Loader ==> Registry
+
+    Trigger ==> Executor
+    Sched ==> Executor
+    Trigger -. 失败时 .-> NM
+    Sched -. 失败时 .-> NM
+    FIM -. 检测到变动 .-> NM
+    ConfW ==> Config
+    Config ==> Secrets
+    Config ==> NM
+
+    Registry ==> FileOps
+    Registry ==> Archives
+    Registry ==> DataOps
+    Registry ==> TextOps
+    Registry ==> Misc
+    Registry ==> Http
+    Registry ==> Drive
+    Registry ==> S3M
+    Registry ==> Azure
+    Registry ==> Dropbox
+    Registry ==> SFTP
+    Registry ==> FTP
+    Registry ==> OneD
+    Registry ==> Box
+    Registry ==> WebDAV
+    Registry ==> SMB
+    Registry ==> Fsspec
+    Registry ==> Cross
+    Registry ==> Crypto
+    Registry ==> Check
+    Registry ==> Fast
+    Registry ==> Dedup
+    Registry ==> Grep
+    Registry ==> Rotate
+    Registry ==> Discovery
+    Registry ==> Builder
+    Registry ==> Progress
+
+    FileOps ==> SafeP
+    Archives ==> SafeP
+    Misc ==> SafeP
+
+    Http ==> UrlVal
+    Http ==> Retry
+    Http ==> Progress
+    Http ==> Check
+    S3M ==> Progress
+    WebDAV ==> UrlVal
+    NM ==> UrlVal
+    NM ==> Sinks
+
+    Cross ==> Drive
+    Cross ==> S3M
+    Cross ==> Azure
+    Cross ==> Dropbox
+    Cross ==> SFTP
+    Cross ==> FTP
+
+    classDef entry fill:#FDEDEC,stroke:#641E16,stroke-width:3px,color:#000,font-weight:bold;
+    classDef facade fill:#D6EAF8,stroke:#154360,stroke-width:4px,color:#000,font-weight:bold;
+    classDef core fill:#FEF9E7,stroke:#1F3A93,stroke-width:3px,color:#000,font-weight:bold;
+    classDef rel fill:#D1F2EB,stroke:#0B5345,stroke-width:3px,color:#000,font-weight:bold;
+    classDef obs fill:#FDEBD0,stroke:#9C640C,stroke-width:3px,color:#000,font-weight:bold;
+    classDef sec fill:#F5B7B1,stroke:#78281F,stroke-width:3px,color:#000,font-weight:bold;
+    classDef event fill:#FCF3CF,stroke:#7D6608,stroke-width:3px,color:#000,font-weight:bold;
+    classDef server fill:#FADBD8,stroke:#922B21,stroke-width:3px,color:#000,font-weight:bold;
+    classDef ui fill:#AED6F1,stroke:#1B4F72,stroke-width:3px,color:#000,font-weight:bold;
+    classDef localOps fill:#E8DAEF,stroke:#512E5F,stroke-width:3px,color:#000,font-weight:bold;
+    classDef remote fill:#D5F5E3,stroke:#196F3D,stroke-width:3px,color:#000,font-weight:bold;
+    classDef notify fill:#F9E79F,stroke:#7D6608,stroke-width:3px,color:#000,font-weight:bold;
+    classDef utils fill:#EAEDED,stroke:#212F3C,stroke-width:3px,color:#000,font-weight:bold;
+
+    class CLI,GUIUser,ClientSDK,MCPHost,Plugins entry;
+    class PublicAPI facade;
+    class Registry,Executor,DAG,Callback,Loader,Queue,Json,Sub core;
+    class Retry,QuotaMod,Breaker,RL,Locks rel;
+    class Progress,Metrics,Audit,Tracing,FIM obs;
+    class Secrets,Config,ConfW,Crypto,Check,SafeP,ACL sec;
+    class Trigger,Sched event;
+    class TCP,HTTPS,MCP,MetSrv,WebUI server;
+    class MainWin,Worker ui;
+    class FileOps,Archives,DataOps,TextOps,Misc localOps;
+    class UrlVal,Http,Drive,S3M,Azure,Dropbox,SFTP,FTP,OneD,Box,WebDAV,SMB,Fsspec,Cross remote;
+    class NM,Sinks notify;
+    class Fast,Dedup,Grep,Rotate,Discovery,Builder utils;
+
+    linkStyle default stroke:#1F2A44,stroke-width:2.5px;
 ```
 
 `build_default_registry()` 构建的 `ActionRegistry` 是所有 `FA_*` 命令的唯一

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -53,105 +53,235 @@ TCP / HTTP 伺服器執行的 JSON 驅動動作。內附 PySide6 GUI，每個功
 ## 架構
 
 ```mermaid
-flowchart LR
-    User[User / CLI / JSON batch]
+flowchart TD
+    CLI["<b>CLI / JSON 批次</b><br/>python -m automation_file"]
+    GUIUser["<b>PySide6 GUI</b><br/>launch_ui"]
+    ClientSDK["<b>HTTPActionClient SDK</b>"]
+    MCPHost["<b>MCP 主機</b><br/>Claude Desktop · MCP CLIs"]
+    Plugins["<b>進入點外掛</b><br/>automation_file.actions"]
 
-    subgraph Facade["automation_file (facade)"]
-        Public["Public API<br/>execute_action, execute_action_parallel,<br/>validate_action, driver_instance,<br/>start_autocontrol_socket_server,<br/>start_http_action_server, Quota,<br/>retry_on_transient, safe_join, ..."]
+    subgraph Facade["<b>automation_file &mdash; 門面 (__init__.py)</b>"]
+        PublicAPI["<b>Public API</b><br/>execute_action · execute_action_parallel · execute_action_dag<br/>validate_action · driver_instance · s3_instance · azure_blob_instance<br/>dropbox_instance · sftp_instance · ftp_instance · onedrive_instance · box_instance<br/>start_autocontrol_socket_server · start_http_action_server<br/>start_metrics_server · start_web_ui · MCPServer<br/>notification_manager · scheduler · trigger_manager<br/>AutomationConfig · progress_registry · Quota · retry_on_transient"]
     end
 
-    subgraph Core["core"]
-        Registry[(ActionRegistry<br/>FA_* commands)]
-        Executor[ActionExecutor]
-        Callback[CallbackExecutor]
-        Loader[PackageLoader]
-        Json[json_store]
-        Retry[retry]
-        QuotaMod[quota]
-        Progress[progress<br/>Token + Reporter]
+    subgraph Core["<b>core 核心</b>"]
+        Registry[("<b>ActionRegistry</b><br/>FA_* 指令")]
+        Executor["<b>ActionExecutor</b><br/>序列 · 並行 · dry-run · validate-first"]
+        DAG["<b>dag_executor</b><br/>拓樸排程 fan-out"]
+        Callback["<b>CallbackExecutor</b>"]
+        Loader["<b>PackageLoader</b><br/>+ 進入點外掛"]
+        Queue["<b>ActionQueue</b>"]
+        Json["<b>json_store</b>"]
+        Sub["<b>substitution</b><br/>${env:} ${date:} ${uuid}"]
     end
 
-    subgraph Events["event-driven"]
-        TriggerMod["trigger<br/>watchdog file watcher"]
-        SchedulerMod["scheduler<br/>cron background thread"]
+    subgraph Reliability["<b>可靠性</b>"]
+        Retry["<b>retry</b><br/>@retry_on_transient"]
+        QuotaMod["<b>Quota</b><br/>位元組 + 時間配額"]
+        Breaker["<b>CircuitBreaker</b>"]
+        RL["<b>RateLimiter</b>"]
+        Locks["<b>FileLock</b> · <b>SQLiteLock</b>"]
     end
 
-    subgraph Local["local"]
-        FileOps[file_ops]
-        DirOps[dir_ops]
-        ZipOps[zip_ops]
-        Safe[safe_paths]
+    subgraph Observability["<b>可觀測性</b>"]
+        Progress["<b>progress</b><br/>CancellationToken · Reporter"]
+        Metrics["<b>metrics</b><br/>Prometheus counters + histograms"]
+        Audit["<b>AuditLog</b><br/>SQLite 稽核紀錄"]
+        Tracing["<b>tracing</b><br/>OpenTelemetry spans"]
+        FIM["<b>IntegrityMonitor</b>"]
     end
 
-    subgraph Remote["remote"]
-        UrlVal[url_validator]
-        Http[http_download]
-        Drive["google_drive<br/>client + *_ops"]
-        S3["s3"]
-        Azure["azure_blob"]
-        Dropbox["dropbox_api"]
-        SFTP["sftp"]
+    subgraph Security["<b>安全 &amp; 設定</b>"]
+        Secrets["<b>Secret providers</b><br/>Env · File · Chained"]
+        Config["<b>AutomationConfig</b><br/>TOML 載入器"]
+        ConfW["<b>ConfigWatcher</b><br/>熱重載"]
+        Crypto["<b>crypto</b><br/>AES-256-GCM"]
+        Check["<b>checksum</b> / <b>manifest</b>"]
+        SafeP["<b>safe_paths</b><br/>safe_join · is_within"]
+        ACL["<b>ActionACL</b>"]
     end
 
-    subgraph Server["server"]
-        TCP[TCPActionServer]
-        HTTP[HTTPActionServer]
+    subgraph Events["<b>事件驅動</b>"]
+        Trigger["<b>TriggerManager</b><br/>watchdog 檔案監聽"]
+        Sched["<b>Scheduler</b><br/>5-field cron + overlap guard"]
     end
 
-    subgraph UI["ui (PySide6)"]
-        Launcher[launch_ui]
-        MainWindow["MainWindow<br/>9-tab control surface"]
+    subgraph Servers["<b>伺服器</b>"]
+        TCP["<b>TCPActionServer</b><br/>loopback · AUTH secret"]
+        HTTPS["<b>HTTPActionServer</b><br/>POST /actions · Bearer<br/>/healthz /readyz /progress /openapi.json"]
+        MCP["<b>MCPServer</b><br/>JSON-RPC 2.0 (stdio)"]
+        MetSrv["<b>MetricsServer</b><br/>/metrics"]
+        WebUI["<b>WebUIServer</b><br/>HTMX dashboard"]
     end
 
-    subgraph Project["project / utils"]
-        Builder[ProjectBuilder]
-        Templates[templates]
-        Discovery[file_discovery]
+    subgraph UI["<b>ui (PySide6)</b>"]
+        MainWin["<b>MainWindow</b><br/>Home · Local · HTTP · Drive · S3 · Azure · Dropbox<br/>SFTP · OneDrive · Box · JSON · Triggers · Scheduler<br/>Progress · Transfer · Servers"]
+        Worker["<b>ActionWorker</b><br/>QRunnable on QThreadPool"]
     end
 
-    User --> Public
-    User --> Launcher
-    Launcher --> MainWindow
-    MainWindow --> Public
-    Public --> Executor
-    Public --> Callback
-    Public --> Loader
-    Public --> TCP
-    Public --> HTTP
+    subgraph Local["<b>本地 ops</b>"]
+        FileOps["<b>file_ops</b> · <b>dir_ops</b>"]
+        Archives["<b>zip_ops</b> · <b>tar_ops</b> · <b>archive_ops</b>"]
+        DataOps["<b>data_ops</b><br/>csv · jsonl · parquet · yaml"]
+        TextOps["<b>text_ops</b> · <b>diff_ops</b><br/><b>json_edit</b> · <b>templates</b>"]
+        Misc["<b>shell_ops</b> · <b>sync_ops</b> · <b>trash</b><br/><b>versioning</b> · <b>conditional</b> · <b>mime</b>"]
+    end
 
-    Executor --> Registry
-    Executor --> Retry
-    Executor --> QuotaMod
-    Callback --> Registry
-    Loader --> Registry
-    TCP --> Executor
-    HTTP --> Executor
-    Executor --> Json
+    subgraph Remote["<b>遠端後端</b>"]
+        UrlVal["<b>url_validator</b><br/>SSRF 防護"]
+        Http["<b>http_download</b><br/>retry · resume · SHA-256"]
+        Drive["<b>google_drive</b>"]
+        S3M["<b>s3</b>"]
+        Azure["<b>azure_blob</b>"]
+        Dropbox["<b>dropbox_api</b>"]
+        SFTP["<b>sftp</b> (RejectPolicy)"]
+        FTP["<b>ftp / FTPS</b>"]
+        OneD["<b>onedrive</b>"]
+        Box["<b>box</b>"]
+        WebDAV["<b>webdav</b>"]
+        SMB["<b>smb / cifs</b>"]
+        Fsspec["<b>fsspec_bridge</b>"]
+        Cross["<b>cross_backend</b><br/>local:// s3:// drive:// azure://<br/>dropbox:// sftp:// ftp://"]
+    end
 
-    Registry --> FileOps
-    Registry --> DirOps
-    Registry --> ZipOps
-    Registry --> Safe
-    Registry --> Http
-    Registry --> Drive
-    Registry --> S3
-    Registry --> Azure
-    Registry --> Dropbox
-    Registry --> SFTP
-    Registry --> Builder
-    Registry --> TriggerMod
-    Registry --> SchedulerMod
-    Registry --> Progress
+    subgraph Notify["<b>通知</b>"]
+        NM["<b>NotificationManager</b><br/>fanout · dedup · SSRF guard"]
+        Sinks["<b>Sinks</b><br/>Webhook · Slack · Email<br/>Telegram · Discord · Teams · PagerDuty"]
+    end
 
-    TriggerMod --> Executor
-    SchedulerMod --> Executor
-    Http --> Progress
-    S3 --> Progress
+    subgraph Utils["<b>工具 / 專案</b>"]
+        Fast["<b>fast_find</b><br/>mdfind / locate / es.exe"]
+        Dedup["<b>find_duplicates</b>"]
+        Grep["<b>grep_files</b>"]
+        Rotate["<b>rotate_backups</b>"]
+        Discovery["<b>file_discovery</b>"]
+        Builder["<b>ProjectBuilder</b> + templates"]
+    end
 
-    Http --> UrlVal
-    Http --> Retry
-    Builder --> Templates
-    Builder --> Discovery
+    CLI ==> PublicAPI
+    GUIUser ==> MainWin
+    ClientSDK ==> HTTPS
+    MCPHost ==> MCP
+    Plugins ==> Loader
+
+    MainWin ==> Worker
+    Worker ==> PublicAPI
+
+    PublicAPI ==> Executor
+    PublicAPI ==> DAG
+    PublicAPI ==> Callback
+    PublicAPI ==> Queue
+    PublicAPI ==> Config
+    PublicAPI ==> NM
+    PublicAPI ==> Trigger
+    PublicAPI ==> Sched
+
+    TCP ==> Executor
+    HTTPS ==> Executor
+    MCP ==> Registry
+    MetSrv ==> Metrics
+    WebUI ==> Registry
+    ACL ==> TCP
+    ACL ==> HTTPS
+
+    Executor ==> Registry
+    Executor ==> Sub
+    Executor ==> Retry
+    Executor ==> QuotaMod
+    Executor ==> Metrics
+    Executor ==> Audit
+    Executor ==> Tracing
+    Executor ==> Json
+    DAG ==> Executor
+    Callback ==> Registry
+    Loader ==> Registry
+
+    Trigger ==> Executor
+    Sched ==> Executor
+    Trigger -. 失敗時 .-> NM
+    Sched -. 失敗時 .-> NM
+    FIM -. 偵測到異動 .-> NM
+    ConfW ==> Config
+    Config ==> Secrets
+    Config ==> NM
+
+    Registry ==> FileOps
+    Registry ==> Archives
+    Registry ==> DataOps
+    Registry ==> TextOps
+    Registry ==> Misc
+    Registry ==> Http
+    Registry ==> Drive
+    Registry ==> S3M
+    Registry ==> Azure
+    Registry ==> Dropbox
+    Registry ==> SFTP
+    Registry ==> FTP
+    Registry ==> OneD
+    Registry ==> Box
+    Registry ==> WebDAV
+    Registry ==> SMB
+    Registry ==> Fsspec
+    Registry ==> Cross
+    Registry ==> Crypto
+    Registry ==> Check
+    Registry ==> Fast
+    Registry ==> Dedup
+    Registry ==> Grep
+    Registry ==> Rotate
+    Registry ==> Discovery
+    Registry ==> Builder
+    Registry ==> Progress
+
+    FileOps ==> SafeP
+    Archives ==> SafeP
+    Misc ==> SafeP
+
+    Http ==> UrlVal
+    Http ==> Retry
+    Http ==> Progress
+    Http ==> Check
+    S3M ==> Progress
+    WebDAV ==> UrlVal
+    NM ==> UrlVal
+    NM ==> Sinks
+
+    Cross ==> Drive
+    Cross ==> S3M
+    Cross ==> Azure
+    Cross ==> Dropbox
+    Cross ==> SFTP
+    Cross ==> FTP
+
+    classDef entry fill:#FDEDEC,stroke:#641E16,stroke-width:3px,color:#000,font-weight:bold;
+    classDef facade fill:#D6EAF8,stroke:#154360,stroke-width:4px,color:#000,font-weight:bold;
+    classDef core fill:#FEF9E7,stroke:#1F3A93,stroke-width:3px,color:#000,font-weight:bold;
+    classDef rel fill:#D1F2EB,stroke:#0B5345,stroke-width:3px,color:#000,font-weight:bold;
+    classDef obs fill:#FDEBD0,stroke:#9C640C,stroke-width:3px,color:#000,font-weight:bold;
+    classDef sec fill:#F5B7B1,stroke:#78281F,stroke-width:3px,color:#000,font-weight:bold;
+    classDef event fill:#FCF3CF,stroke:#7D6608,stroke-width:3px,color:#000,font-weight:bold;
+    classDef server fill:#FADBD8,stroke:#922B21,stroke-width:3px,color:#000,font-weight:bold;
+    classDef ui fill:#AED6F1,stroke:#1B4F72,stroke-width:3px,color:#000,font-weight:bold;
+    classDef localOps fill:#E8DAEF,stroke:#512E5F,stroke-width:3px,color:#000,font-weight:bold;
+    classDef remote fill:#D5F5E3,stroke:#196F3D,stroke-width:3px,color:#000,font-weight:bold;
+    classDef notify fill:#F9E79F,stroke:#7D6608,stroke-width:3px,color:#000,font-weight:bold;
+    classDef utils fill:#EAEDED,stroke:#212F3C,stroke-width:3px,color:#000,font-weight:bold;
+
+    class CLI,GUIUser,ClientSDK,MCPHost,Plugins entry;
+    class PublicAPI facade;
+    class Registry,Executor,DAG,Callback,Loader,Queue,Json,Sub core;
+    class Retry,QuotaMod,Breaker,RL,Locks rel;
+    class Progress,Metrics,Audit,Tracing,FIM obs;
+    class Secrets,Config,ConfW,Crypto,Check,SafeP,ACL sec;
+    class Trigger,Sched event;
+    class TCP,HTTPS,MCP,MetSrv,WebUI server;
+    class MainWin,Worker ui;
+    class FileOps,Archives,DataOps,TextOps,Misc localOps;
+    class UrlVal,Http,Drive,S3M,Azure,Dropbox,SFTP,FTP,OneD,Box,WebDAV,SMB,Fsspec,Cross remote;
+    class NM,Sinks notify;
+    class Fast,Dedup,Grep,Rotate,Discovery,Builder utils;
+
+    linkStyle default stroke:#1F2A44,stroke-width:2.5px;
 ```
 
 `build_default_registry()` 建立的 `ActionRegistry` 是所有 `FA_*` 指令的唯一

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx>=7.4.7
 sphinx-rtd-theme
 myst-parser
+sphinxcontrib-mermaid

--- a/docs/source.zh-CN/architecture.rst
+++ b/docs/source.zh-CN/architecture.rst
@@ -3,6 +3,249 @@
 
 ``automation_file`` 采用分层架构，核心由五种设计模式组成：
 
+系统总览
+--------
+
+下图展示完整的派发表面：任何调用方——CLI、GUI、HTTP/MCP 客户端、入口点插件
+——最终都会落到由 ``build_default_registry()`` 填充的共享 ``ActionRegistry``，
+再从 registry 向本地 ops、远程后端、可靠性 / 安全 / 可观测性辅助工具、通知，
+以及事件驱动的触发器与 cron 调度器扇出。
+
+.. mermaid::
+
+   flowchart TD
+       CLI["<b>CLI / JSON 批次</b><br/>python -m automation_file"]
+       GUIUser["<b>PySide6 GUI</b><br/>launch_ui"]
+       ClientSDK["<b>HTTPActionClient SDK</b>"]
+       MCPHost["<b>MCP 主机</b><br/>Claude Desktop · MCP CLIs"]
+       Plugins["<b>入口点插件</b><br/>automation_file.actions"]
+
+       subgraph Facade["<b>automation_file &mdash; 门面 (__init__.py)</b>"]
+           PublicAPI["<b>Public API</b><br/>execute_action · execute_action_parallel · execute_action_dag<br/>validate_action · driver_instance · s3_instance · azure_blob_instance<br/>dropbox_instance · sftp_instance · ftp_instance · onedrive_instance · box_instance<br/>start_autocontrol_socket_server · start_http_action_server<br/>start_metrics_server · start_web_ui · MCPServer<br/>notification_manager · scheduler · trigger_manager<br/>AutomationConfig · progress_registry · Quota · retry_on_transient"]
+       end
+
+       subgraph Core["<b>core 核心</b>"]
+           Registry[("<b>ActionRegistry</b><br/>FA_* 命令")]
+           Executor["<b>ActionExecutor</b><br/>串行 · 并行 · dry-run · validate-first"]
+           DAG["<b>dag_executor</b><br/>拓扑调度 fan-out"]
+           Callback["<b>CallbackExecutor</b>"]
+           Loader["<b>PackageLoader</b><br/>+ 入口点插件"]
+           Queue["<b>ActionQueue</b>"]
+           Json["<b>json_store</b>"]
+           Sub["<b>substitution</b><br/>${env:} ${date:} ${uuid}"]
+       end
+
+       subgraph Reliability["<b>可靠性</b>"]
+           Retry["<b>retry</b><br/>@retry_on_transient"]
+           QuotaMod["<b>Quota</b><br/>字节 + 时间配额"]
+           Breaker["<b>CircuitBreaker</b>"]
+           RL["<b>RateLimiter</b>"]
+           Locks["<b>FileLock</b> · <b>SQLiteLock</b>"]
+       end
+
+       subgraph Observability["<b>可观测性</b>"]
+           Progress["<b>progress</b><br/>CancellationToken · Reporter"]
+           Metrics["<b>metrics</b><br/>Prometheus counters + histograms"]
+           Audit["<b>AuditLog</b><br/>SQLite 审计日志"]
+           Tracing["<b>tracing</b><br/>OpenTelemetry spans"]
+           FIM["<b>IntegrityMonitor</b>"]
+       end
+
+       subgraph Security["<b>安全 &amp; 配置</b>"]
+           Secrets["<b>Secret providers</b><br/>Env · File · Chained"]
+           Config["<b>AutomationConfig</b><br/>TOML 加载器"]
+           ConfW["<b>ConfigWatcher</b><br/>热重载"]
+           Crypto["<b>crypto</b><br/>AES-256-GCM"]
+           Check["<b>checksum</b> / <b>manifest</b>"]
+           SafeP["<b>safe_paths</b><br/>safe_join · is_within"]
+           ACL["<b>ActionACL</b>"]
+       end
+
+       subgraph Events["<b>事件驱动</b>"]
+           Trigger["<b>TriggerManager</b><br/>watchdog 文件监听"]
+           Sched["<b>Scheduler</b><br/>5-field cron + overlap guard"]
+       end
+
+       subgraph Servers["<b>服务器</b>"]
+           TCP["<b>TCPActionServer</b><br/>loopback · AUTH secret"]
+           HTTPS["<b>HTTPActionServer</b><br/>POST /actions · Bearer<br/>/healthz /readyz /progress /openapi.json"]
+           MCP["<b>MCPServer</b><br/>JSON-RPC 2.0 (stdio)"]
+           MetSrv["<b>MetricsServer</b><br/>/metrics"]
+           WebUI["<b>WebUIServer</b><br/>HTMX dashboard"]
+       end
+
+       subgraph UI["<b>ui (PySide6)</b>"]
+           MainWin["<b>MainWindow</b><br/>Home · Local · HTTP · Drive · S3 · Azure · Dropbox<br/>SFTP · OneDrive · Box · JSON · Triggers · Scheduler<br/>Progress · Transfer · Servers"]
+           Worker["<b>ActionWorker</b><br/>QRunnable on QThreadPool"]
+       end
+
+       subgraph Local["<b>本地 ops</b>"]
+           FileOps["<b>file_ops</b> · <b>dir_ops</b>"]
+           Archives["<b>zip_ops</b> · <b>tar_ops</b> · <b>archive_ops</b>"]
+           DataOps["<b>data_ops</b><br/>csv · jsonl · parquet · yaml"]
+           TextOps["<b>text_ops</b> · <b>diff_ops</b><br/><b>json_edit</b> · <b>templates</b>"]
+           Misc["<b>shell_ops</b> · <b>sync_ops</b> · <b>trash</b><br/><b>versioning</b> · <b>conditional</b> · <b>mime</b>"]
+       end
+
+       subgraph Remote["<b>远程后端</b>"]
+           UrlVal["<b>url_validator</b><br/>SSRF 保护"]
+           Http["<b>http_download</b><br/>retry · resume · SHA-256"]
+           Drive["<b>google_drive</b>"]
+           S3M["<b>s3</b>"]
+           Azure["<b>azure_blob</b>"]
+           Dropbox["<b>dropbox_api</b>"]
+           SFTP["<b>sftp</b> (RejectPolicy)"]
+           FTP["<b>ftp / FTPS</b>"]
+           OneD["<b>onedrive</b>"]
+           Box["<b>box</b>"]
+           WebDAV["<b>webdav</b>"]
+           SMB["<b>smb / cifs</b>"]
+           Fsspec["<b>fsspec_bridge</b>"]
+           Cross["<b>cross_backend</b><br/>local:// s3:// drive:// azure://<br/>dropbox:// sftp:// ftp://"]
+       end
+
+       subgraph Notify["<b>通知</b>"]
+           NM["<b>NotificationManager</b><br/>fanout · dedup · SSRF guard"]
+           Sinks["<b>Sinks</b><br/>Webhook · Slack · Email<br/>Telegram · Discord · Teams · PagerDuty"]
+       end
+
+       subgraph Utils["<b>工具 / 项目</b>"]
+           Fast["<b>fast_find</b><br/>mdfind / locate / es.exe"]
+           Dedup["<b>find_duplicates</b>"]
+           Grep["<b>grep_files</b>"]
+           Rotate["<b>rotate_backups</b>"]
+           Discovery["<b>file_discovery</b>"]
+           Builder["<b>ProjectBuilder</b> + templates"]
+       end
+
+       CLI ==> PublicAPI
+       GUIUser ==> MainWin
+       ClientSDK ==> HTTPS
+       MCPHost ==> MCP
+       Plugins ==> Loader
+
+       MainWin ==> Worker
+       Worker ==> PublicAPI
+
+       PublicAPI ==> Executor
+       PublicAPI ==> DAG
+       PublicAPI ==> Callback
+       PublicAPI ==> Queue
+       PublicAPI ==> Config
+       PublicAPI ==> NM
+       PublicAPI ==> Trigger
+       PublicAPI ==> Sched
+
+       TCP ==> Executor
+       HTTPS ==> Executor
+       MCP ==> Registry
+       MetSrv ==> Metrics
+       WebUI ==> Registry
+       ACL ==> TCP
+       ACL ==> HTTPS
+
+       Executor ==> Registry
+       Executor ==> Sub
+       Executor ==> Retry
+       Executor ==> QuotaMod
+       Executor ==> Metrics
+       Executor ==> Audit
+       Executor ==> Tracing
+       Executor ==> Json
+       DAG ==> Executor
+       Callback ==> Registry
+       Loader ==> Registry
+
+       Trigger ==> Executor
+       Sched ==> Executor
+       Trigger -. 失败时 .-> NM
+       Sched -. 失败时 .-> NM
+       FIM -. 检测到变动 .-> NM
+       ConfW ==> Config
+       Config ==> Secrets
+       Config ==> NM
+
+       Registry ==> FileOps
+       Registry ==> Archives
+       Registry ==> DataOps
+       Registry ==> TextOps
+       Registry ==> Misc
+       Registry ==> Http
+       Registry ==> Drive
+       Registry ==> S3M
+       Registry ==> Azure
+       Registry ==> Dropbox
+       Registry ==> SFTP
+       Registry ==> FTP
+       Registry ==> OneD
+       Registry ==> Box
+       Registry ==> WebDAV
+       Registry ==> SMB
+       Registry ==> Fsspec
+       Registry ==> Cross
+       Registry ==> Crypto
+       Registry ==> Check
+       Registry ==> Fast
+       Registry ==> Dedup
+       Registry ==> Grep
+       Registry ==> Rotate
+       Registry ==> Discovery
+       Registry ==> Builder
+       Registry ==> Progress
+
+       FileOps ==> SafeP
+       Archives ==> SafeP
+       Misc ==> SafeP
+
+       Http ==> UrlVal
+       Http ==> Retry
+       Http ==> Progress
+       Http ==> Check
+       S3M ==> Progress
+       WebDAV ==> UrlVal
+       NM ==> UrlVal
+       NM ==> Sinks
+
+       Cross ==> Drive
+       Cross ==> S3M
+       Cross ==> Azure
+       Cross ==> Dropbox
+       Cross ==> SFTP
+       Cross ==> FTP
+
+       classDef entry fill:#FDEDEC,stroke:#641E16,stroke-width:3px,color:#000,font-weight:bold;
+       classDef facade fill:#D6EAF8,stroke:#154360,stroke-width:4px,color:#000,font-weight:bold;
+       classDef core fill:#FEF9E7,stroke:#1F3A93,stroke-width:3px,color:#000,font-weight:bold;
+       classDef rel fill:#D1F2EB,stroke:#0B5345,stroke-width:3px,color:#000,font-weight:bold;
+       classDef obs fill:#FDEBD0,stroke:#9C640C,stroke-width:3px,color:#000,font-weight:bold;
+       classDef sec fill:#F5B7B1,stroke:#78281F,stroke-width:3px,color:#000,font-weight:bold;
+       classDef event fill:#FCF3CF,stroke:#7D6608,stroke-width:3px,color:#000,font-weight:bold;
+       classDef server fill:#FADBD8,stroke:#922B21,stroke-width:3px,color:#000,font-weight:bold;
+       classDef ui fill:#AED6F1,stroke:#1B4F72,stroke-width:3px,color:#000,font-weight:bold;
+       classDef localOps fill:#E8DAEF,stroke:#512E5F,stroke-width:3px,color:#000,font-weight:bold;
+       classDef remote fill:#D5F5E3,stroke:#196F3D,stroke-width:3px,color:#000,font-weight:bold;
+       classDef notify fill:#F9E79F,stroke:#7D6608,stroke-width:3px,color:#000,font-weight:bold;
+       classDef utils fill:#EAEDED,stroke:#212F3C,stroke-width:3px,color:#000,font-weight:bold;
+
+       class CLI,GUIUser,ClientSDK,MCPHost,Plugins entry;
+       class PublicAPI facade;
+       class Registry,Executor,DAG,Callback,Loader,Queue,Json,Sub core;
+       class Retry,QuotaMod,Breaker,RL,Locks rel;
+       class Progress,Metrics,Audit,Tracing,FIM obs;
+       class Secrets,Config,ConfW,Crypto,Check,SafeP,ACL sec;
+       class Trigger,Sched event;
+       class TCP,HTTPS,MCP,MetSrv,WebUI server;
+       class MainWin,Worker ui;
+       class FileOps,Archives,DataOps,TextOps,Misc localOps;
+       class UrlVal,Http,Drive,S3M,Azure,Dropbox,SFTP,FTP,OneD,Box,WebDAV,SMB,Fsspec,Cross remote;
+       class NM,Sinks notify;
+       class Fast,Dedup,Grep,Rotate,Discovery,Builder utils;
+
+       linkStyle default stroke:#1F2A44,stroke-width:2.5px;
+
+设计模式
+--------
+
 **Facade（外观）**
    :mod:`automation_file`（顶层 ``__init__``）是使用者唯一需要导入的名称。
    所有公开函数与单例都从这里重新导出。

--- a/docs/source.zh-CN/conf.py
+++ b/docs/source.zh-CN/conf.py
@@ -22,6 +22,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "myst_parser",
+    "sphinxcontrib.mermaid",
 ]
 
 templates_path = ["../source/_templates"]

--- a/docs/source.zh-TW/architecture.rst
+++ b/docs/source.zh-TW/architecture.rst
@@ -3,6 +3,249 @@
 
 ``automation_file`` 採用分層架構，核心由五種設計模式組成：
 
+系統總覽
+--------
+
+下圖展示完整的派送表面：任何呼叫端——CLI、GUI、HTTP/MCP 客戶端、進入點外掛
+——最終都會落到由 ``build_default_registry()`` 填充的共用 ``ActionRegistry``，
+再從 registry 向本地 ops、遠端後端、可靠性 / 安全 / 可觀測性輔助工具、通知、
+以及事件驅動的觸發器與 cron 排程器扇出。
+
+.. mermaid::
+
+   flowchart TD
+       CLI["<b>CLI / JSON 批次</b><br/>python -m automation_file"]
+       GUIUser["<b>PySide6 GUI</b><br/>launch_ui"]
+       ClientSDK["<b>HTTPActionClient SDK</b>"]
+       MCPHost["<b>MCP 主機</b><br/>Claude Desktop · MCP CLIs"]
+       Plugins["<b>進入點外掛</b><br/>automation_file.actions"]
+
+       subgraph Facade["<b>automation_file &mdash; 門面 (__init__.py)</b>"]
+           PublicAPI["<b>Public API</b><br/>execute_action · execute_action_parallel · execute_action_dag<br/>validate_action · driver_instance · s3_instance · azure_blob_instance<br/>dropbox_instance · sftp_instance · ftp_instance · onedrive_instance · box_instance<br/>start_autocontrol_socket_server · start_http_action_server<br/>start_metrics_server · start_web_ui · MCPServer<br/>notification_manager · scheduler · trigger_manager<br/>AutomationConfig · progress_registry · Quota · retry_on_transient"]
+       end
+
+       subgraph Core["<b>core 核心</b>"]
+           Registry[("<b>ActionRegistry</b><br/>FA_* 指令")]
+           Executor["<b>ActionExecutor</b><br/>序列 · 並行 · dry-run · validate-first"]
+           DAG["<b>dag_executor</b><br/>拓樸排程 fan-out"]
+           Callback["<b>CallbackExecutor</b>"]
+           Loader["<b>PackageLoader</b><br/>+ 進入點外掛"]
+           Queue["<b>ActionQueue</b>"]
+           Json["<b>json_store</b>"]
+           Sub["<b>substitution</b><br/>${env:} ${date:} ${uuid}"]
+       end
+
+       subgraph Reliability["<b>可靠性</b>"]
+           Retry["<b>retry</b><br/>@retry_on_transient"]
+           QuotaMod["<b>Quota</b><br/>位元組 + 時間配額"]
+           Breaker["<b>CircuitBreaker</b>"]
+           RL["<b>RateLimiter</b>"]
+           Locks["<b>FileLock</b> · <b>SQLiteLock</b>"]
+       end
+
+       subgraph Observability["<b>可觀測性</b>"]
+           Progress["<b>progress</b><br/>CancellationToken · Reporter"]
+           Metrics["<b>metrics</b><br/>Prometheus counters + histograms"]
+           Audit["<b>AuditLog</b><br/>SQLite 稽核紀錄"]
+           Tracing["<b>tracing</b><br/>OpenTelemetry spans"]
+           FIM["<b>IntegrityMonitor</b>"]
+       end
+
+       subgraph Security["<b>安全 &amp; 設定</b>"]
+           Secrets["<b>Secret providers</b><br/>Env · File · Chained"]
+           Config["<b>AutomationConfig</b><br/>TOML 載入器"]
+           ConfW["<b>ConfigWatcher</b><br/>熱重載"]
+           Crypto["<b>crypto</b><br/>AES-256-GCM"]
+           Check["<b>checksum</b> / <b>manifest</b>"]
+           SafeP["<b>safe_paths</b><br/>safe_join · is_within"]
+           ACL["<b>ActionACL</b>"]
+       end
+
+       subgraph Events["<b>事件驅動</b>"]
+           Trigger["<b>TriggerManager</b><br/>watchdog 檔案監聽"]
+           Sched["<b>Scheduler</b><br/>5-field cron + overlap guard"]
+       end
+
+       subgraph Servers["<b>伺服器</b>"]
+           TCP["<b>TCPActionServer</b><br/>loopback · AUTH secret"]
+           HTTPS["<b>HTTPActionServer</b><br/>POST /actions · Bearer<br/>/healthz /readyz /progress /openapi.json"]
+           MCP["<b>MCPServer</b><br/>JSON-RPC 2.0 (stdio)"]
+           MetSrv["<b>MetricsServer</b><br/>/metrics"]
+           WebUI["<b>WebUIServer</b><br/>HTMX dashboard"]
+       end
+
+       subgraph UI["<b>ui (PySide6)</b>"]
+           MainWin["<b>MainWindow</b><br/>Home · Local · HTTP · Drive · S3 · Azure · Dropbox<br/>SFTP · OneDrive · Box · JSON · Triggers · Scheduler<br/>Progress · Transfer · Servers"]
+           Worker["<b>ActionWorker</b><br/>QRunnable on QThreadPool"]
+       end
+
+       subgraph Local["<b>本地 ops</b>"]
+           FileOps["<b>file_ops</b> · <b>dir_ops</b>"]
+           Archives["<b>zip_ops</b> · <b>tar_ops</b> · <b>archive_ops</b>"]
+           DataOps["<b>data_ops</b><br/>csv · jsonl · parquet · yaml"]
+           TextOps["<b>text_ops</b> · <b>diff_ops</b><br/><b>json_edit</b> · <b>templates</b>"]
+           Misc["<b>shell_ops</b> · <b>sync_ops</b> · <b>trash</b><br/><b>versioning</b> · <b>conditional</b> · <b>mime</b>"]
+       end
+
+       subgraph Remote["<b>遠端後端</b>"]
+           UrlVal["<b>url_validator</b><br/>SSRF 防護"]
+           Http["<b>http_download</b><br/>retry · resume · SHA-256"]
+           Drive["<b>google_drive</b>"]
+           S3M["<b>s3</b>"]
+           Azure["<b>azure_blob</b>"]
+           Dropbox["<b>dropbox_api</b>"]
+           SFTP["<b>sftp</b> (RejectPolicy)"]
+           FTP["<b>ftp / FTPS</b>"]
+           OneD["<b>onedrive</b>"]
+           Box["<b>box</b>"]
+           WebDAV["<b>webdav</b>"]
+           SMB["<b>smb / cifs</b>"]
+           Fsspec["<b>fsspec_bridge</b>"]
+           Cross["<b>cross_backend</b><br/>local:// s3:// drive:// azure://<br/>dropbox:// sftp:// ftp://"]
+       end
+
+       subgraph Notify["<b>通知</b>"]
+           NM["<b>NotificationManager</b><br/>fanout · dedup · SSRF guard"]
+           Sinks["<b>Sinks</b><br/>Webhook · Slack · Email<br/>Telegram · Discord · Teams · PagerDuty"]
+       end
+
+       subgraph Utils["<b>工具 / 專案</b>"]
+           Fast["<b>fast_find</b><br/>mdfind / locate / es.exe"]
+           Dedup["<b>find_duplicates</b>"]
+           Grep["<b>grep_files</b>"]
+           Rotate["<b>rotate_backups</b>"]
+           Discovery["<b>file_discovery</b>"]
+           Builder["<b>ProjectBuilder</b> + templates"]
+       end
+
+       CLI ==> PublicAPI
+       GUIUser ==> MainWin
+       ClientSDK ==> HTTPS
+       MCPHost ==> MCP
+       Plugins ==> Loader
+
+       MainWin ==> Worker
+       Worker ==> PublicAPI
+
+       PublicAPI ==> Executor
+       PublicAPI ==> DAG
+       PublicAPI ==> Callback
+       PublicAPI ==> Queue
+       PublicAPI ==> Config
+       PublicAPI ==> NM
+       PublicAPI ==> Trigger
+       PublicAPI ==> Sched
+
+       TCP ==> Executor
+       HTTPS ==> Executor
+       MCP ==> Registry
+       MetSrv ==> Metrics
+       WebUI ==> Registry
+       ACL ==> TCP
+       ACL ==> HTTPS
+
+       Executor ==> Registry
+       Executor ==> Sub
+       Executor ==> Retry
+       Executor ==> QuotaMod
+       Executor ==> Metrics
+       Executor ==> Audit
+       Executor ==> Tracing
+       Executor ==> Json
+       DAG ==> Executor
+       Callback ==> Registry
+       Loader ==> Registry
+
+       Trigger ==> Executor
+       Sched ==> Executor
+       Trigger -. 失敗時 .-> NM
+       Sched -. 失敗時 .-> NM
+       FIM -. 偵測到異動 .-> NM
+       ConfW ==> Config
+       Config ==> Secrets
+       Config ==> NM
+
+       Registry ==> FileOps
+       Registry ==> Archives
+       Registry ==> DataOps
+       Registry ==> TextOps
+       Registry ==> Misc
+       Registry ==> Http
+       Registry ==> Drive
+       Registry ==> S3M
+       Registry ==> Azure
+       Registry ==> Dropbox
+       Registry ==> SFTP
+       Registry ==> FTP
+       Registry ==> OneD
+       Registry ==> Box
+       Registry ==> WebDAV
+       Registry ==> SMB
+       Registry ==> Fsspec
+       Registry ==> Cross
+       Registry ==> Crypto
+       Registry ==> Check
+       Registry ==> Fast
+       Registry ==> Dedup
+       Registry ==> Grep
+       Registry ==> Rotate
+       Registry ==> Discovery
+       Registry ==> Builder
+       Registry ==> Progress
+
+       FileOps ==> SafeP
+       Archives ==> SafeP
+       Misc ==> SafeP
+
+       Http ==> UrlVal
+       Http ==> Retry
+       Http ==> Progress
+       Http ==> Check
+       S3M ==> Progress
+       WebDAV ==> UrlVal
+       NM ==> UrlVal
+       NM ==> Sinks
+
+       Cross ==> Drive
+       Cross ==> S3M
+       Cross ==> Azure
+       Cross ==> Dropbox
+       Cross ==> SFTP
+       Cross ==> FTP
+
+       classDef entry fill:#FDEDEC,stroke:#641E16,stroke-width:3px,color:#000,font-weight:bold;
+       classDef facade fill:#D6EAF8,stroke:#154360,stroke-width:4px,color:#000,font-weight:bold;
+       classDef core fill:#FEF9E7,stroke:#1F3A93,stroke-width:3px,color:#000,font-weight:bold;
+       classDef rel fill:#D1F2EB,stroke:#0B5345,stroke-width:3px,color:#000,font-weight:bold;
+       classDef obs fill:#FDEBD0,stroke:#9C640C,stroke-width:3px,color:#000,font-weight:bold;
+       classDef sec fill:#F5B7B1,stroke:#78281F,stroke-width:3px,color:#000,font-weight:bold;
+       classDef event fill:#FCF3CF,stroke:#7D6608,stroke-width:3px,color:#000,font-weight:bold;
+       classDef server fill:#FADBD8,stroke:#922B21,stroke-width:3px,color:#000,font-weight:bold;
+       classDef ui fill:#AED6F1,stroke:#1B4F72,stroke-width:3px,color:#000,font-weight:bold;
+       classDef localOps fill:#E8DAEF,stroke:#512E5F,stroke-width:3px,color:#000,font-weight:bold;
+       classDef remote fill:#D5F5E3,stroke:#196F3D,stroke-width:3px,color:#000,font-weight:bold;
+       classDef notify fill:#F9E79F,stroke:#7D6608,stroke-width:3px,color:#000,font-weight:bold;
+       classDef utils fill:#EAEDED,stroke:#212F3C,stroke-width:3px,color:#000,font-weight:bold;
+
+       class CLI,GUIUser,ClientSDK,MCPHost,Plugins entry;
+       class PublicAPI facade;
+       class Registry,Executor,DAG,Callback,Loader,Queue,Json,Sub core;
+       class Retry,QuotaMod,Breaker,RL,Locks rel;
+       class Progress,Metrics,Audit,Tracing,FIM obs;
+       class Secrets,Config,ConfW,Crypto,Check,SafeP,ACL sec;
+       class Trigger,Sched event;
+       class TCP,HTTPS,MCP,MetSrv,WebUI server;
+       class MainWin,Worker ui;
+       class FileOps,Archives,DataOps,TextOps,Misc localOps;
+       class UrlVal,Http,Drive,S3M,Azure,Dropbox,SFTP,FTP,OneD,Box,WebDAV,SMB,Fsspec,Cross remote;
+       class NM,Sinks notify;
+       class Fast,Dedup,Grep,Rotate,Discovery,Builder utils;
+
+       linkStyle default stroke:#1F2A44,stroke-width:2.5px;
+
+設計模式
+--------
+
 **Facade（外觀）**
    :mod:`automation_file`（頂層 ``__init__``）是使用者唯一需要匯入的名稱。
    所有公開函式與單例都從這裡重新匯出。

--- a/docs/source.zh-TW/conf.py
+++ b/docs/source.zh-TW/conf.py
@@ -22,6 +22,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "myst_parser",
+    "sphinxcontrib.mermaid",
 ]
 
 templates_path = ["../source/_templates"]

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -4,6 +4,251 @@ Architecture
 ``automation_file`` follows a layered architecture built around five design
 patterns:
 
+System overview
+---------------
+
+The diagram below shows the full dispatch surface: every caller — CLI, GUI,
+HTTP/MCP clients, entry-point plugins — eventually lands in the shared
+``ActionRegistry`` that ``build_default_registry()`` populates, and the
+registry fans out to local ops, remote backends, reliability / security /
+observability helpers, notifications, and the event-driven trigger + cron
+dispatchers.
+
+.. mermaid::
+
+   flowchart TD
+       CLI["<b>CLI / JSON batch</b><br/>python -m automation_file"]
+       GUIUser["<b>PySide6 GUI</b><br/>launch_ui"]
+       ClientSDK["<b>HTTPActionClient SDK</b>"]
+       MCPHost["<b>MCP hosts</b><br/>Claude Desktop · MCP CLIs"]
+       Plugins["<b>Entry-point plugins</b><br/>automation_file.actions"]
+
+       subgraph Facade["<b>automation_file &mdash; facade (__init__.py)</b>"]
+           PublicAPI["<b>Public API</b><br/>execute_action · execute_action_parallel · execute_action_dag<br/>validate_action · driver_instance · s3_instance · azure_blob_instance<br/>dropbox_instance · sftp_instance · ftp_instance · onedrive_instance · box_instance<br/>start_autocontrol_socket_server · start_http_action_server<br/>start_metrics_server · start_web_ui · MCPServer<br/>notification_manager · scheduler · trigger_manager<br/>AutomationConfig · progress_registry · Quota · retry_on_transient"]
+       end
+
+       subgraph Core["<b>core</b>"]
+           Registry[("<b>ActionRegistry</b><br/>FA_* commands")]
+           Executor["<b>ActionExecutor</b><br/>serial · parallel · dry-run · validate-first"]
+           DAG["<b>dag_executor</b><br/>topological fan-out"]
+           Callback["<b>CallbackExecutor</b>"]
+           Loader["<b>PackageLoader</b><br/>+ entry-point plugins"]
+           Queue["<b>ActionQueue</b>"]
+           Json["<b>json_store</b>"]
+           Sub["<b>substitution</b><br/>${env:} ${date:} ${uuid}"]
+       end
+
+       subgraph Reliability["<b>reliability</b>"]
+           Retry["<b>retry</b><br/>@retry_on_transient"]
+           QuotaMod["<b>Quota</b><br/>bytes + time budget"]
+           Breaker["<b>CircuitBreaker</b>"]
+           RL["<b>RateLimiter</b>"]
+           Locks["<b>FileLock</b> · <b>SQLiteLock</b>"]
+       end
+
+       subgraph Observability["<b>observability</b>"]
+           Progress["<b>progress</b><br/>CancellationToken · Reporter"]
+           Metrics["<b>metrics</b><br/>Prometheus counters + histograms"]
+           Audit["<b>AuditLog</b><br/>SQLite"]
+           Tracing["<b>tracing</b><br/>OpenTelemetry spans"]
+           FIM["<b>IntegrityMonitor</b>"]
+       end
+
+       subgraph Security["<b>security &amp; config</b>"]
+           Secrets["<b>Secret providers</b><br/>Env · File · Chained"]
+           Config["<b>AutomationConfig</b><br/>TOML loader"]
+           ConfW["<b>ConfigWatcher</b><br/>hot reload"]
+           Crypto["<b>crypto</b><br/>AES-256-GCM"]
+           Check["<b>checksum</b> / <b>manifest</b>"]
+           SafeP["<b>safe_paths</b><br/>safe_join · is_within"]
+           ACL["<b>ActionACL</b>"]
+       end
+
+       subgraph Events["<b>event-driven</b>"]
+           Trigger["<b>TriggerManager</b><br/>watchdog file watcher"]
+           Sched["<b>Scheduler</b><br/>5-field cron + overlap guard"]
+       end
+
+       subgraph Servers["<b>servers</b>"]
+           TCP["<b>TCPActionServer</b><br/>loopback · AUTH secret"]
+           HTTPS["<b>HTTPActionServer</b><br/>POST /actions · Bearer<br/>/healthz /readyz /progress /openapi.json"]
+           MCP["<b>MCPServer</b><br/>JSON-RPC 2.0 (stdio)"]
+           MetSrv["<b>MetricsServer</b><br/>/metrics"]
+           WebUI["<b>WebUIServer</b><br/>HTMX dashboard"]
+       end
+
+       subgraph UI["<b>ui (PySide6)</b>"]
+           MainWin["<b>MainWindow</b><br/>Home · Local · HTTP · Drive · S3 · Azure · Dropbox<br/>SFTP · OneDrive · Box · JSON · Triggers · Scheduler<br/>Progress · Transfer · Servers"]
+           Worker["<b>ActionWorker</b><br/>QRunnable on QThreadPool"]
+       end
+
+       subgraph Local["<b>local ops</b>"]
+           FileOps["<b>file_ops</b> · <b>dir_ops</b>"]
+           Archives["<b>zip_ops</b> · <b>tar_ops</b> · <b>archive_ops</b>"]
+           DataOps["<b>data_ops</b><br/>csv · jsonl · parquet · yaml"]
+           TextOps["<b>text_ops</b> · <b>diff_ops</b><br/><b>json_edit</b> · <b>templates</b>"]
+           Misc["<b>shell_ops</b> · <b>sync_ops</b> · <b>trash</b><br/><b>versioning</b> · <b>conditional</b> · <b>mime</b>"]
+       end
+
+       subgraph Remote["<b>remote backends</b>"]
+           UrlVal["<b>url_validator</b><br/>SSRF guard"]
+           Http["<b>http_download</b><br/>retry · resume · SHA-256"]
+           Drive["<b>google_drive</b>"]
+           S3M["<b>s3</b>"]
+           Azure["<b>azure_blob</b>"]
+           Dropbox["<b>dropbox_api</b>"]
+           SFTP["<b>sftp</b> (RejectPolicy)"]
+           FTP["<b>ftp / FTPS</b>"]
+           OneD["<b>onedrive</b>"]
+           Box["<b>box</b>"]
+           WebDAV["<b>webdav</b>"]
+           SMB["<b>smb / cifs</b>"]
+           Fsspec["<b>fsspec_bridge</b>"]
+           Cross["<b>cross_backend</b><br/>local:// s3:// drive:// azure://<br/>dropbox:// sftp:// ftp://"]
+       end
+
+       subgraph Notify["<b>notifications</b>"]
+           NM["<b>NotificationManager</b><br/>fanout · dedup · SSRF guard"]
+           Sinks["<b>Sinks</b><br/>Webhook · Slack · Email<br/>Telegram · Discord · Teams · PagerDuty"]
+       end
+
+       subgraph Utils["<b>utils / project</b>"]
+           Fast["<b>fast_find</b><br/>mdfind / locate / es.exe"]
+           Dedup["<b>find_duplicates</b>"]
+           Grep["<b>grep_files</b>"]
+           Rotate["<b>rotate_backups</b>"]
+           Discovery["<b>file_discovery</b>"]
+           Builder["<b>ProjectBuilder</b> + templates"]
+       end
+
+       CLI ==> PublicAPI
+       GUIUser ==> MainWin
+       ClientSDK ==> HTTPS
+       MCPHost ==> MCP
+       Plugins ==> Loader
+
+       MainWin ==> Worker
+       Worker ==> PublicAPI
+
+       PublicAPI ==> Executor
+       PublicAPI ==> DAG
+       PublicAPI ==> Callback
+       PublicAPI ==> Queue
+       PublicAPI ==> Config
+       PublicAPI ==> NM
+       PublicAPI ==> Trigger
+       PublicAPI ==> Sched
+
+       TCP ==> Executor
+       HTTPS ==> Executor
+       MCP ==> Registry
+       MetSrv ==> Metrics
+       WebUI ==> Registry
+       ACL ==> TCP
+       ACL ==> HTTPS
+
+       Executor ==> Registry
+       Executor ==> Sub
+       Executor ==> Retry
+       Executor ==> QuotaMod
+       Executor ==> Metrics
+       Executor ==> Audit
+       Executor ==> Tracing
+       Executor ==> Json
+       DAG ==> Executor
+       Callback ==> Registry
+       Loader ==> Registry
+
+       Trigger ==> Executor
+       Sched ==> Executor
+       Trigger -. on failure .-> NM
+       Sched -. on failure .-> NM
+       FIM -. on drift .-> NM
+       ConfW ==> Config
+       Config ==> Secrets
+       Config ==> NM
+
+       Registry ==> FileOps
+       Registry ==> Archives
+       Registry ==> DataOps
+       Registry ==> TextOps
+       Registry ==> Misc
+       Registry ==> Http
+       Registry ==> Drive
+       Registry ==> S3M
+       Registry ==> Azure
+       Registry ==> Dropbox
+       Registry ==> SFTP
+       Registry ==> FTP
+       Registry ==> OneD
+       Registry ==> Box
+       Registry ==> WebDAV
+       Registry ==> SMB
+       Registry ==> Fsspec
+       Registry ==> Cross
+       Registry ==> Crypto
+       Registry ==> Check
+       Registry ==> Fast
+       Registry ==> Dedup
+       Registry ==> Grep
+       Registry ==> Rotate
+       Registry ==> Discovery
+       Registry ==> Builder
+       Registry ==> Progress
+
+       FileOps ==> SafeP
+       Archives ==> SafeP
+       Misc ==> SafeP
+
+       Http ==> UrlVal
+       Http ==> Retry
+       Http ==> Progress
+       Http ==> Check
+       S3M ==> Progress
+       WebDAV ==> UrlVal
+       NM ==> UrlVal
+       NM ==> Sinks
+
+       Cross ==> Drive
+       Cross ==> S3M
+       Cross ==> Azure
+       Cross ==> Dropbox
+       Cross ==> SFTP
+       Cross ==> FTP
+
+       classDef entry fill:#FDEDEC,stroke:#641E16,stroke-width:3px,color:#000,font-weight:bold;
+       classDef facade fill:#D6EAF8,stroke:#154360,stroke-width:4px,color:#000,font-weight:bold;
+       classDef core fill:#FEF9E7,stroke:#1F3A93,stroke-width:3px,color:#000,font-weight:bold;
+       classDef rel fill:#D1F2EB,stroke:#0B5345,stroke-width:3px,color:#000,font-weight:bold;
+       classDef obs fill:#FDEBD0,stroke:#9C640C,stroke-width:3px,color:#000,font-weight:bold;
+       classDef sec fill:#F5B7B1,stroke:#78281F,stroke-width:3px,color:#000,font-weight:bold;
+       classDef event fill:#FCF3CF,stroke:#7D6608,stroke-width:3px,color:#000,font-weight:bold;
+       classDef server fill:#FADBD8,stroke:#922B21,stroke-width:3px,color:#000,font-weight:bold;
+       classDef ui fill:#AED6F1,stroke:#1B4F72,stroke-width:3px,color:#000,font-weight:bold;
+       classDef localOps fill:#E8DAEF,stroke:#512E5F,stroke-width:3px,color:#000,font-weight:bold;
+       classDef remote fill:#D5F5E3,stroke:#196F3D,stroke-width:3px,color:#000,font-weight:bold;
+       classDef notify fill:#F9E79F,stroke:#7D6608,stroke-width:3px,color:#000,font-weight:bold;
+       classDef utils fill:#EAEDED,stroke:#212F3C,stroke-width:3px,color:#000,font-weight:bold;
+
+       class CLI,GUIUser,ClientSDK,MCPHost,Plugins entry;
+       class PublicAPI facade;
+       class Registry,Executor,DAG,Callback,Loader,Queue,Json,Sub core;
+       class Retry,QuotaMod,Breaker,RL,Locks rel;
+       class Progress,Metrics,Audit,Tracing,FIM obs;
+       class Secrets,Config,ConfW,Crypto,Check,SafeP,ACL sec;
+       class Trigger,Sched event;
+       class TCP,HTTPS,MCP,MetSrv,WebUI server;
+       class MainWin,Worker ui;
+       class FileOps,Archives,DataOps,TextOps,Misc localOps;
+       class UrlVal,Http,Drive,S3M,Azure,Dropbox,SFTP,FTP,OneD,Box,WebDAV,SMB,Fsspec,Cross remote;
+       class NM,Sinks notify;
+       class Fast,Dedup,Grep,Rotate,Discovery,Builder utils;
+
+       linkStyle default stroke:#1F2A44,stroke-width:2.5px;
+
+Design patterns
+---------------
+
 **Facade**
    :mod:`automation_file` (the top-level ``__init__``) is the only name users
    should need to import. Every public function and singleton is re-exported

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "myst_parser",
+    "sphinxcontrib.mermaid",
 ]
 
 templates_path = ["_templates"]


### PR DESCRIPTION
## Summary
- Replace the legacy mermaid flowchart in `README.md` / `README.zh-TW.md` / `README.zh-CN.md` with a comprehensive system diagram that covers every current subsystem (DAG executor, triggers, scheduler, notifications, observability, all remote backends — OneDrive / Box / WebDAV / SMB / FTP / fsspec — MCP / metrics / web UI servers, crypto, audit, FIM, config + secrets).
- Apply bold box borders (3–4px strokes), bold labels (`<b>…</b>`), and thick arrows (`==>` with `linkStyle default stroke-width:2.5px`) so the graph reads well at README zoom.
- Add a new **System overview** section with the same mermaid diagram to `docs/source/architecture.rst`, `docs/source.zh-TW/architecture.rst`, and `docs/source.zh-CN/architecture.rst`; wire it through `sphinxcontrib-mermaid` (added to `docs/requirements.txt` and all three Sphinx `conf.py` extension lists).

## Test plan
- [ ] `README.md` renders the new mermaid diagram on GitHub (verify subgraph color classes and bold arrows).
- [ ] `README.zh-TW.md` and `README.zh-CN.md` render with the translated subgraph labels.
- [ ] RTD / local Sphinx build (`pip install -r docs/requirements.txt && sphinx-build -b html docs/source docs/_build/html`) succeeds and the **System overview** section renders the mermaid diagram for each language.
- [ ] `ruff check automation_file/ tests/` and `python -m pytest tests/ -v` still pass (docs-only change, no code).