### PR TITLE
Silence Codacy Bandit B105 false positive in executor leak test

### DIFF
--- a/tests/test_action_executor.py
+++ b/tests/test_action_executor.py
@@ -112,20 +112,16 @@ def test_duplicate_actions_do_not_collide() -> None:
     assert list(results.values()) == ["first", "first"]
 
 
-def test_substitute_does_not_leak_into_result_key() -> None:
+def test_substitute_does_not_leak_into_result_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """``substitute=True`` must keep the un-expanded literal in result keys."""
-    import os
-
-    os.environ["FA_EXEC_SECRET"] = "TOP_SECRET"
-    try:
-        executor = _fresh_executor()
-        results = executor.execute_action(
-            [["echo", {"value": "${env:FA_EXEC_SECRET}"}]],
-            substitute=True,
-        )
-        [(key, value)] = results.items()
-        assert "TOP_SECRET" not in key
-        assert "${env:FA_EXEC_SECRET}" in key
-        assert value == "TOP_SECRET"
-    finally:
-        os.environ.pop("FA_EXEC_SECRET", None)
+    sentinel = "sentinel-must-not-appear-in-key"
+    monkeypatch.setenv("FA_EXEC_LEAK_PROBE", sentinel)
+    executor = _fresh_executor()
+    results = executor.execute_action(
+        [["echo", {"value": "${env:FA_EXEC_LEAK_PROBE}"}]],
+        substitute=True,
+    )
+    [(key, value)] = results.items()
+    assert sentinel not in key
+    assert "${env:FA_EXEC_LEAK_PROBE}" in key
+    assert value == sentinel


### PR DESCRIPTION
## Summary
PR #61 added `test_substitute_does_not_leak_into_result_key` with a literal `os.environ["FA_EXEC_SECRET"] = "TOP_SECRET"` to verify substituted env values don't leak into result keys. Codacy/Bandit flagged this as **B105 — Possible hardcoded password** (PR #62 / dev → main blocked on it).

This is a test-only false positive — the literal is a deliberately recognisable sentinel, not a credential. Refactor instead of suppressing:
- Switch to pytest's `monkeypatch` (matching the existing pattern in `test_substitution.py`); auto-cleans, no try/finally needed.
- Rename env var so the key no longer contains "SECRET".
- Use a non-credential-looking sentinel value.

Behaviour under test is unchanged — still proves the un-substituted literal stays in the result key while the expanded value only reaches the callable.

## Test plan
- [x] `pytest tests/test_action_executor.py` — 13 passed locally
- [ ] Codacy clean on this PR
- [ ] CI matrix green