### PR TITLE
Restore Windows double-decode for --execute_str

### DIFF
--- a/automation_file/__main__.py
+++ b/automation_file/__main__.py
@@ -38,7 +38,14 @@ def _execute_dir(path: str) -> Any:
 
 
 def _execute_str(raw: str) -> Any:
-    return execute_action(json.loads(raw))
+    parsed = json.loads(raw)
+    # PyBreeze (and other launchers) double-encode the action list on Windows
+    # to survive command-line escaping — peel the second JSON layer if we got
+    # a string back. Guarded by isinstance, so callers that pass a single-encoded
+    # payload still work on every platform.
+    if isinstance(parsed, str):
+        parsed = json.loads(parsed)
+    return execute_action(parsed)
 
 
 _LEGACY_DISPATCH: dict[str, Callable[[str], Any]] = {

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from typing import Any
+
 import pytest
 
 from automation_file import __main__ as cli_main
@@ -55,3 +58,40 @@ def test_mcp_subcommand_omits_allowed_actions_when_unset(
     assert rc == 0
     assert "--allowed-actions" not in captured["argv"]
     assert captured["argv"] == ["--name", "automation_file", "--version", "1.0.0"]
+
+
+def _capture_execute_action(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    received: list[Any] = []
+
+    def _fake_execute(action_list: Any) -> dict:
+        received.append(action_list)
+        return {}
+
+    monkeypatch.setattr(cli_main, "execute_action", _fake_execute)
+    return received
+
+
+def test_execute_str_accepts_single_encoded_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    received = _capture_execute_action(monkeypatch)
+    actions = [["FA_create_file", {"file_path": "x.txt", "content": "hi"}]]
+
+    rc = cli_main.main(["--execute_str", json.dumps(actions)])
+
+    assert rc == 0
+    assert received == [actions]
+
+
+def test_execute_str_accepts_double_encoded_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    received = _capture_execute_action(monkeypatch)
+    actions = [["FA_create_file", {"file_path": "x.txt", "content": "hi"}]]
+
+    # PyBreeze on Windows wraps the JSON list once more before handing the
+    # argument to subprocess; the CLI must peel both layers off.
+    rc = cli_main.main(["--execute_str", json.dumps(json.dumps(actions))])
+
+    assert rc == 0
+    assert received == [actions]


### PR DESCRIPTION
## Summary
- PyBreeze (and other launchers) double-encode the action list on Windows to survive command-line escaping. The registry refactor dropped the matching peel step in `_execute_str`, so `python -m automation_file --execute_str <payload>` rejected PyBreeze's payload with `action_list must be list, got str`.
- `_execute_str` now unwraps a second JSON layer when the first decode yields a string. Guarded by `isinstance(parsed, str)` so single-encoded payloads work too — no platform check, same behaviour everywhere.
- Adds two tests (`tests/test_cli_main.py`) covering the single- and double-encoded payload shapes.

## Test plan
- [x] `pytest tests/test_cli_main.py` — 4/4 pass
- [x] Full suite: 743 passed (16 deselected = optional `pyarrow` parquet path, unrelated)
- [x] End-to-end `subprocess.Popen([..., "-m", "automation_file", "--execute_str", json.dumps(json.dumps(actions))])` — RC 0, target file written
- [x] `ruff check` / `ruff format --check` clean on changed files