### PR TITLE
Give each top-level doc its own toctree caption

### DIFF
--- a/docs/source.zh-CN/index.rst
+++ b/docs/source.zh-CN/index.rst
@@ -159,10 +159,20 @@ JSON 动作列表就是上述 list 的 list。
 
 .. toctree::
    :maxdepth: 2
-   :caption: 文档
+   :caption: 架构
 
    architecture
+
+.. toctree::
+   :maxdepth: 3
+   :caption: 使用指南
+
    usage/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API 参考
+
    api/index
 
 索引

--- a/docs/source.zh-TW/index.rst
+++ b/docs/source.zh-TW/index.rst
@@ -159,10 +159,20 @@ JSON 動作清單就是上述 list 的 list。
 
 .. toctree::
    :maxdepth: 2
-   :caption: 文件
+   :caption: 架構
 
    architecture
+
+.. toctree::
+   :maxdepth: 3
+   :caption: 使用指南
+
    usage/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API 參考
+
    api/index
 
 索引

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -162,10 +162,20 @@ A JSON action list is simply a list of these lists.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Documentation
+   :caption: Architecture
 
    architecture
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Usage guide
+
    usage/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API reference
+
    api/index
 
 Indices


### PR DESCRIPTION
## Summary
- Split the single ``Documentation`` toctree on each landing page into three captioned toctrees — **Architecture**, **Usage guide**, **API reference** — so the Sphinx sidebar renders them as distinct chapters instead of a flat group.
- Mirrored across English (``docs/source``), 简体中文 (``docs/source.zh-CN``), and 繁體中文 (``docs/source.zh-TW``).
- Inside the Usage guide chapter the existing five sub-captions (Getting started, Local & transfer, Servers & integrations, Reliability & events, Configuration & extension) continue to render as their own sections.

## Test plan
- [x] ``sphinx-build -b html docs/source docs/_build/html`` exits 0
- [x] ``sphinx-build -b html docs/source.zh-CN docs/_build/html-zh-CN`` exits 0
- [x] ``sphinx-build -b html docs/source.zh-TW docs/_build/html-zh-TW`` exits 0
- [x] Rendered HTML grep confirms three top-level captions per language plus five usage sub-captions