### PR TITLE
Configure docs as three Read the Docs translation projects

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,11 @@
 # .readthedocs.yaml
-# Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Read the Docs configuration file for the English ("fileautomation") project.
+# Sibling files .readthedocs.zh-TW.yaml and .readthedocs.zh-CN.yaml configure
+# the two translation projects. Wire each translation project to its own YAML
+# in the RTD project admin (Settings → Default settings → Path), and link the
+# three projects via the main project's Translations tab.
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+#     https://docs.readthedocs.io/en/stable/localization.html
 
 # Required
 version: 2
@@ -11,7 +16,7 @@ build:
   tools:
     python: "3.11"
 
-# Build documentation in the "docs/" directory with Sphinx
+# Build the English documentation in docs/source with Sphinx.
 sphinx:
    configuration: docs/source/conf.py
 

--- a/.readthedocs.zh-CN.yaml
+++ b/.readthedocs.zh-CN.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.zh-CN.yaml
+# Read the Docs configuration file for the Simplified Chinese
+# ("fileautomation-zh-cn") translation project. Linked from the main
+# "fileautomation" project's Translations tab so RTD serves it at
+# https://fileautomation.readthedocs.io/zh_CN/<version>/.
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+#     https://docs.readthedocs.io/en/stable/localization.html
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build the Simplified Chinese documentation in docs/source.zh-CN with Sphinx.
+sphinx:
+   configuration: docs/source.zh-CN/conf.py
+
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/.readthedocs.zh-TW.yaml
+++ b/.readthedocs.zh-TW.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.zh-TW.yaml
+# Read the Docs configuration file for the Traditional Chinese
+# ("fileautomation-zh-tw") translation project. Linked from the main
+# "fileautomation" project's Translations tab so RTD serves it at
+# https://fileautomation.readthedocs.io/zh_TW/<version>/.
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+#     https://docs.readthedocs.io/en/stable/localization.html
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build the Traditional Chinese documentation in docs/source.zh-TW with Sphinx.
+sphinx:
+   configuration: docs/source.zh-TW/conf.py
+
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/docs/source.zh-CN/conf.py
+++ b/docs/source.zh-CN/conf.py
@@ -16,6 +16,12 @@ release = "0.0.32"
 language = "zh_CN"
 html_title = "automation_file 文档（简体中文）"
 
+# Read the Docs sets READTHEDOCS_CANONICAL_URL to the per-translation canonical
+# URL (e.g. https://fileautomation.readthedocs.io/zh_CN/latest/). Use it as the
+# base URL so canonical <link rel="canonical"> tags and the translations flyout
+# resolve correctly. Empty string off-RTD.
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",

--- a/docs/source.zh-CN/index.rst
+++ b/docs/source.zh-CN/index.rst
@@ -17,7 +17,13 @@ Dropbox、OneDrive、Box、SFTP、FTP / FTPS、WebDAV、SMB、fsspec）、
 * **Issue / 未来规划**：https://github.com/Integration-Automation/FileAutomation/issues
 * **许可**：MIT
 
-语言：`English <../html/index.html>`_ | `繁體中文 <../html-zh-TW/index.html>`_ | **简体中文**
+语言：`English <https://fileautomation.readthedocs.io/en/latest/>`_ | `繁體中文 <https://fileautomation.readthedocs.io/zh_TW/latest/>`_ | **简体中文**
+
+.. note::
+
+   每个语言都是独立的 Read the Docs 项目，并挂在主项目
+   ``fileautomation`` 下作为翻译。RTD 也会在每页右下角的版本菜单中
+   自动提供语言切换器。
 
 .. contents:: 本页目录
    :local:

--- a/docs/source.zh-TW/conf.py
+++ b/docs/source.zh-TW/conf.py
@@ -16,6 +16,12 @@ release = "0.0.32"
 language = "zh_TW"
 html_title = "automation_file 文件（繁體中文）"
 
+# Read the Docs sets READTHEDOCS_CANONICAL_URL to the per-translation canonical
+# URL (e.g. https://fileautomation.readthedocs.io/zh_TW/latest/). Use it as the
+# base URL so canonical <link rel="canonical"> tags and the translations flyout
+# resolve correctly. Empty string off-RTD.
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",

--- a/docs/source.zh-TW/index.rst
+++ b/docs/source.zh-TW/index.rst
@@ -17,7 +17,13 @@ Dropbox、OneDrive、Box、SFTP、FTP / FTPS、WebDAV、SMB、fsspec）、
 * **Issue / 未來規劃**：https://github.com/Integration-Automation/FileAutomation/issues
 * **授權**：MIT
 
-語言：`English <../html/index.html>`_ | **繁體中文** | `简体中文 <../html-zh-CN/index.html>`_
+語言：`English <https://fileautomation.readthedocs.io/en/latest/>`_ | **繁體中文** | `简体中文 <https://fileautomation.readthedocs.io/zh_CN/latest/>`_
+
+.. note::
+
+   每個語言都是獨立的 Read the Docs 專案，並掛在主專案
+   ``fileautomation`` 下作為翻譯。RTD 也會在每頁右下角的版本選單中
+   自動提供語言切換器。
 
 .. contents:: 本頁目錄
    :local:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,13 @@ project = "automation_file"
 author = "JE-Chen"
 copyright = "2026, JE-Chen"  # pylint: disable=redefined-builtin  # Sphinx requires this name
 release = "0.0.32"
+language = "en"
+
+# Read the Docs sets READTHEDOCS_CANONICAL_URL to the per-translation canonical
+# URL (e.g. https://fileautomation.readthedocs.io/en/latest/). Use it as the
+# base URL so canonical <link rel="canonical"> tags and the translations flyout
+# resolve correctly. Empty string off-RTD.
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,7 +18,13 @@ and exposed from a single ``automation_file`` facade.
 * **Issues / RoadMap** — https://github.com/Integration-Automation/FileAutomation/issues
 * **License** — MIT
 
-Languages: **English** | `繁體中文 <../html-zh-TW/index.html>`_ | `简体中文 <../html-zh-CN/index.html>`_
+Languages: **English** | `繁體中文 <https://fileautomation.readthedocs.io/zh_TW/latest/>`_ | `简体中文 <https://fileautomation.readthedocs.io/zh_CN/latest/>`_
+
+.. note::
+
+   Each language is served as its own Read the Docs project, linked as a
+   translation of ``fileautomation``. RTD also exposes a built-in language
+   selector inside the version flyout in the bottom-right of every page.
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
## Summary

The previous PR shipped a homepage rewrite, but only the English source tree was wired up on Read the Docs — relative ``../html-zh-TW/index.html`` switcher links 404 on the public site because the two Chinese sources are never built or deployed. This PR follows RTD's prescribed multi-language layout: **one project per language**, linked under a main project's *Translations* tab.

- Added `.readthedocs.zh-TW.yaml` and `.readthedocs.zh-CN.yaml` so each Sphinx source tree builds as its own RTD project.
- Annotated the existing ``.readthedocs.yaml`` as the English (main) project config.
- Set ``language = "en"`` on ``docs/source/conf.py`` (was implicit) and pulled ``html_baseurl`` from ``READTHEDOCS_CANONICAL_URL`` on every conf.py so canonical link tags match the per-language URL RTD serves.
- Replaced the relative ``../html-*/index.html`` switcher with absolute ``https://fileautomation.readthedocs.io/<lang>/latest/`` URLs and added a brief note pointing at RTD's built-in language flyout.

## Commits in this PR

- ``5bf51c3`` Configure docs as three Read the Docs translation projects

## Required RTD admin steps after merge

Config alone can't create projects — these steps must happen on https://readthedocs.org:

1. **Create three projects** all pointing at this repo:
   - ``fileautomation`` (main, English)
   - ``fileautomation-zh-tw`` (Traditional Chinese)
   - ``fileautomation-zh-cn`` (Simplified Chinese)
2. For each translation project: **Settings → Default settings → Path for `.readthedocs.yaml`** = ``.readthedocs.zh-TW.yaml`` / ``.readthedocs.zh-CN.yaml``. Set **Language** to Traditional Chinese / Simplified Chinese.
3. On the main ``fileautomation`` project, open the **Translations** tab and link the two translation projects. RTD then serves them at ``/zh_TW/`` and ``/zh_CN/`` and adds an automatic language selector to the version flyout on every page.

## Test plan

- [ ] All three local Sphinx builds succeed with no new toctree / index warnings:
      ``py -m sphinx -b html docs/source       docs/_build/html``
      ``py -m sphinx -b html docs/source.zh-TW docs/_build/html-zh-TW``
      ``py -m sphinx -b html docs/source.zh-CN docs/_build/html-zh-CN``
- [ ] Verify the rendered homepage of each language has the absolute ``https://fileautomation.readthedocs.io/<lang>/latest/`` switcher links.
- [ ] After RTD admin steps: confirm the public site at ``https://fileautomation.readthedocs.io/en/latest/`` shows the language flyout and the in-page switcher links navigate between ``/en/``, ``/zh_TW/``, and ``/zh_CN/``.