### PR TITLE
Ignore ruff PLR0917 to unblock lint

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -20,6 +20,7 @@ select = [
 ignore = [
     "E501",      # line length enforced by formatter
     "PLR0913",   # argparse builders legitimately take > 7 args
+    "PLR0917",   # same rationale as PLR0913; download_file's positional signature is public API
     "PLR2004",   # magic numbers are allowed in tests / CLI
     "PLR0912",   # branch count is bounded by CLAUDE.md (15) not ruff's default
     "PLR0915",   # statement count same


### PR DESCRIPTION
Ruff is installed unpinned in CI (`pip install ruff mypy`), and a recent release stabilised `PLR0917` (too-many-positional-arguments) out of preview. The scheduled `main` run went red on unchanged code:

- `automation_file/local/data_ops.py:66` `_stream_csv_filter` (7)
- `automation_file/local/data_ops.py:102` `_write_filtered_rows` (6)
- `automation_file/remote/http_download.py:182` `download_file` (8)

Adds `PLR0917` to the ignore list next to the existing `PLR0913` entry. `download_file` is exported on the facade and takes its arguments positionally with defaults, so making the signature keyword-only would break callers. The two `data_ops` helpers already carried `# pylint: disable-next=too-many-positional-arguments`, so the exemption was pre-existing intent.

Verified locally against ruff 0.15.14: `ruff check` and `ruff format --check` both pass.